### PR TITLE
Rewrite README.md and CLAUDE.md

### DIFF
--- a/.claudeignore
+++ b/.claudeignore
@@ -1,0 +1,11 @@
+.venv/
+__pycache__/
+*.pyc
+*.pyo
+node_modules/
+.git/
+htmlcov/
+.coverage
+*.egg-info/
+dist/
+build/

--- a/.claudeignore
+++ b/.claudeignore
@@ -9,3 +9,4 @@ htmlcov/
 *.egg-info/
 dist/
 build/
+.envrc

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,229 +1,78 @@
-# CLAUDE.md
+# CLAUDE.md — dime
 
-This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+This is the Python backend repo for dime, an AI agent-driven publishing pipeline. For architecture, specs, decisions, and cross-repo context, see `docs/specs/` and `docs/decisions/` (symlinked from dime-ops).
 
-## Project Overview
-Python package called "dime" - a multi-agent content creation system for political liberation movement analysis using Google ADK. The project uses `uv` as the package manager and requires Python 3.13+.
+## Commands
 
-## Development Commands
+```bash
+# Dependencies
+uv sync
 
-### Package Management
-- **Install dependencies**: `uv sync`
-- **Add a dependency**: `uv add <package-name>`
-- **Add development dependency**: `uv add --dev <package-name>`
-- **Update dependencies**: `uv lock --upgrade`
+# Run
+uv run python -m dime health
+uv run python -m dime start
 
-### Running the Code
-**Important**: Always run applications via `uv`, never call `python` directly.
-- **Start the web server**: `uv run python -m dime start` (starts ADK web interface on http://localhost:8000)
-- **Health check**: `uv run python -m dime health` (validates configuration and system status)
-- **Run any Python file**: `uv run python <filename.py>`
+# Quality
+uv run ruff check .
+uv run ruff format .
+uv run pyright
+uv run pytest
+uv run pytest --cov
+```
 
-### Testing Commands
-- **Run all tests**: `uv run pytest`
-- **Run with coverage**: `uv run pytest --cov`
-- **Run with verbose output**: `uv run pytest -v`
-- **Run specific test file**: `uv run pytest tests/test_config.py`
-- **Generate HTML coverage report**: `uv run pytest --cov --cov-report=html` (opens in `htmlcov/index.html`)
+Always use `uv run` — never call `python` directly.
 
-## Current Project State
+## File structure
 
-### ✅ Phase 0: Foundation - COMPLETED
-The foundation phase has been successfully completed with all critical issues resolved:
-
-1. **✅ Fixed Critical Bugs**: All agent reference errors in `publisher/agent.py` resolved
-2. **✅ CLI Interface**: Implemented CLI with `health` and `start` commands
-3. **✅ ADK Web Interface**: Functional web interface using Google ADK's `get_fast_api_app()`
-4. **✅ Agent System**: Proper ADK agent structure with automatic discovery
-5. **✅ Configuration System**: Simplified case-sensitive configuration with automatic field mapping
-
-### Current Working Components
-- **✅ Configuration System**: Simplified Pydantic Settings with case-sensitive environment variable mapping
-- **✅ CLI Interface**: `uv run python -m dime health` and `uv run python -m dime start` commands
-- **✅ ADK Web Interface**: Functional web interface at http://localhost:8000/ when server is running
-- **✅ Agent Discovery**: Proper ADK agent structure in `agents/dime_agent/` directory
-- **✅ Environment Management**: direnv integration with `.envrc` (contains secrets, not tracked)
-- **✅ Package Management**: Modern uv-based dependency management
-- **✅ Git Workflow**: Gitflow methodology with protected main/develop branches
-- **✅ Testing Framework**: pytest with 93% code coverage and comprehensive test suite
-
-### Next Phase Requirements
-- **Enhanced Agent Tools**: Implement more sophisticated content creation tools
-- **Database Integration**: Full PostgreSQL and Redis integration
-- **Production Readiness**: Monitoring, observability, and deployment configuration
-
-## Architecture Overview
-
-### Multi-Agent Content Pipeline (Planned)
-The system is designed as a 7-stage content creation pipeline:
-1. **Topic Selection**: Human-driven topic curation
-2. **Research Agent**: Content research and source gathering
-3. **Fact Checker Agent**: Source validation and credibility scoring
-4. **Writer Agent**: Article creation from research
-5. **Editor Agent**: Style and quality refinement
-6. **Graphics Agent**: Image generation with human approval
-7. **Assembly Agent**: Final document compilation and Git publishing
-
-### Technology Stack
-- **Core Framework**: Google ADK (Agent Development Kit) >= 1.0.0
-- **Web Framework**: FastAPI (planned)
-- **Database**: PostgreSQL with SQLAlchemy (planned)
-- **Caching**: Redis (planned)
-- **Observability**: Logfire for structured logging (configured)
-- **Authentication**: Google OAuth + JWT (planned)
-
-### Current File Structure
 ```
 dime/
-├── dime/                     # Main package (✅ implemented)
-│   ├── __init__.py          # Package initialization
-│   ├── app.py               # ✅ FastAPI application with ADK integration
-│   ├── __main__.py          # ✅ CLI entry point (health, start commands)
-│   └── config/              # ✅ Configuration system (working)
-│       ├── __init__.py
-│       └── settings.py      # ✅ Simplified Pydantic Settings with case-sensitive mapping
-├── agents/                  # ✅ ADK agent directory
-│   └── dime_agent/          # ✅ Main content creation agent
-│       ├── __init__.py
-│       └── agent.py         # ✅ ADK agent with research and writing tools
-├── publisher/               # ✅ Legacy agent code (fixed)
-│   ├── __init__.py
-│   └── agent.py            # ✅ Fixed undefined variable references
-├── tests/                   # ✅ Test suite (93% coverage)
-│   ├── __init__.py
-│   ├── conftest.py         # ✅ Pytest fixtures and configuration
-│   ├── test_config.py      # ✅ Configuration tests
-│   ├── test_cli.py         # ✅ CLI command tests
-│   ├── test_app.py         # ✅ FastAPI application tests
-│   └── test_agents.py      # ✅ Agent functionality tests
-├── docs/                    # Project documentation
-│   └── github_issues/       # Detailed implementation requirements
-├── .envrc                   # Environment variables (contains secrets, git-ignored)
-├── pyproject.toml          # Project configuration
-└── uv.lock                 # Dependency lock file
+  dime/                      # Main package
+    __init__.py
+    __main__.py              # CLI entry point
+    app.py                   # FastAPI app
+    config/
+      settings.py            # Pydantic Settings
+    agents/
+      base.py
+      researcher.py
+      writer.py
+      publisher.py
+  agents/                    # ADK agent discovery
+    dime_agent/
+      agent.py
+  tests/
+  docs/                      # Symlinked to dime-ops/docs/
+    specs/
+    decisions/
+    memory/
+    issues/
+  pyproject.toml
+  uv.lock
 ```
 
-## Key Dependencies
-- **google-adk** (>=1.0.0): Google's Agent Development Kit for multi-agent systems
+## Coding standards
 
-## Coding Guidelines
-- **Always follow PEP 8 styles**: Code style enforced by ruff
-- **Run ruff format on every file after editing**: Auto-formatting required
-- **Do not overengineer**: Simplicity is a virtue
-- **Use uv python package management**: Never use pip directly
-- **Never run `python` directly**: Always use `uv run`
-- **Use Pydantic for typing**: Type validation and serialization
-- **All Python files should end with a single newline character** (PEP 8)
+- PEP 8 enforced by ruff
+- Type hints required — checked by pyright (not mypy)
+- Imports in file header only, never inline
+- All files end with a single newline
+- Pydantic for data validation and settings
+- Start simple — do not overengineer
 
-## Environment Configuration
-- **Environment Management**: Uses direnv with `.envrc` file
-- **Environment Variables**: Comprehensive configuration via environment
-- **Secrets Management**: `.envrc` contains API keys and is git-ignored
-- **Configuration Classes**: Pydantic Settings with nested configuration in `dime.config.settings`
+## Gitflow rules
 
-## Branch Management & Git Workflow
-- **Methodology**: Gitflow workflow (user preference)
-- **Protected Branches**: `main` and `develop` require pull requests with 1 required reviewer
-- **Branch Structure**:
-  - `main`: Production-ready code
-  - `develop`: Integration branch for features
-  - `feature/`: Feature development branches
-  - `hotfix/`: Critical production fixes
-- **No Direct Pushes**: All changes must go through PR process
-- **Status Checks**: All PRs must pass CI tests before merge
-- **Branch Protection**: Force pushes disabled, deletions blocked
+- Never work in `main` or `develop` directly
+- All work in `feature/`, `hotfix/`, or `release/` branches
+- PRs required to merge into `develop` or `main`
+- Commit messages: imperative mood, present tense
 
-## Quality Standards (Phase 0 Requirements)
+## Secrets
 
-### Code Quality
-- **Linting**: Must pass `ruff check .`
-- **Formatting**: Must pass `ruff format --check .`
-- **Type Checking**: 100% type hint coverage required
-- **Complexity**: Cyclomatic complexity <10 per function
-- **Coverage**: ≥90% test coverage required
+- Secrets live in `.envrc` only — never `.env`, never committed
+- `.envrc` is in `.gitignore`
 
-### Testing Requirements
-- **Framework**: pytest (✅ implemented)
-- **Coverage**: pytest-cov with ≥90% line coverage (✅ 93% achieved)
-- **Test Types**: Unit tests for core logic, integration tests for ADK workflows
-- **Performance**: Test suite must complete in <60 seconds (✅ ~2.3 seconds)
-- **Test Suite**: 20 tests covering config, CLI, app, and agents
+## Testing
 
-### Performance Criteria
-- **Application Startup**: System starts in <10 seconds
-- **Health Check Response**: <200ms response time
-- **Memory Usage**: Base footprint <200MB
-- **Agent Response**: Basic conversations <5 seconds
-
-## Development Interfaces
-
-### CLI Interface
-- **Health Check**: `uv run python -m dime health` - validates configuration and displays system status
-- **Start Server**: `uv run python -m dime start` - launches ADK web interface on http://localhost:8000
-- **Custom Host/Port**: `uv run python -m dime start --host 127.0.0.1 --port 3000`
-
-### ADK Web Interface
-When running `uv run python -m dime start`, the following interfaces become available:
-- **Main Interface**: http://localhost:8000/ - Interactive ADK agent conversations
-- **Developer UI**: http://localhost:8000/dev-ui/ - ADK development and debugging tools
-- **Agent Discovery**: Automatic discovery and loading of agents from `agents/` directory
-
-### Configuration System
-- **Environment Variables**: All configuration via uppercase environment variables in `.envrc`
-- **Case Sensitivity**: Configuration uses case-sensitive field mapping (e.g., `DATABASE_URL` → `DATABASE_URL`)
-- **Auto-Discovery**: Field names automatically map to environment variables without prefixes or complex field mappings
-- **Validation**: Built-in validation with descriptive error messages
-
-## Issue #4 Completion Status
-1. **✅ COMPLETED**: Fix Critical Bug - Resolved undefined agent references in `publisher/agent.py`
-2. **✅ COMPLETED**: Create Basic Interface - Implemented CLI interface and ADK web interface
-3. **✅ COMPLETED**: Update Documentation - Aligned documentation with actual implementation
-4. **✅ COMPLETED**: Establish Testing - Set up pytest framework with 93% code coverage
-
-### What Was Accomplished
-- ✅ CLI commands (health, start) with argument parsing
-- ✅ ADK web interface using get_fast_api_app()
-- ✅ Agent discovery and basic conversation functionality
-- ✅ Comprehensive test suite with 20 tests
-- ✅ 93% code coverage exceeding 90% requirement
-- ✅ All code quality checks passing (ruff lint/format)
-
-### Remaining Work (Future Phases)
-- Advanced CLI commands (content creation, pipeline management)
-- Database session persistence and testing
-- Production monitoring and observability
-- Security hardening (input validation, XSS protection)
-- Load testing and performance optimization
-
-## Commit and Testing Policy
-- **100% test pass before committing**: No skipping tests allowed
-- **Run ruff format on every file after editing**: Auto-formatting required
-- **When updating existing code, also update tests and fixtures**
-- **Never disable tests instead of fixing them**
-- **Never commit code that doesn't pass tests**
-- **Never make assumptions - verify with existing code**
-- **Always update plan documentation as you go**
-- **Stop after 3 failed attempts and reassess**
-
-## Definition of Done Requirements
-Every commit must:
-- Pass all existing tests (100% pass rate)
-- Include tests for new functionality
-- Follow project formatting/linting standards
-- Have clear commit messages
-- Match planned implementation
-- Include proper error handling with descriptive messages
-- Fail fast with descriptive error messages
-- Include context for debugging
-- Handle errors at appropriate level
-- Never silently swallow exceptions
-
-## Important Notes
-- **Critical Path Blocker**: The undefined agent references must be fixed first
-- **ADK Integration**: Requires proper agent discovery patterns and session management
-- **Content Focus**: System targets political liberation movement analysis
-- **Audience**: Liberal audience, 20-40 years old, college-educated or lay interest in political history
-- **Quality Standards**: Emphasis on source citation and accuracy for historical content
-- Never use inline imports. Imports always go in the header in accordance with PEP8
-- always start with the simplest approach possible
-- end all files with a single newline character in accordance with PEP8
+- pytest with pytest-cov
+- Run `uv run pytest` before every commit
+- Never disable or skip tests instead of fixing them

--- a/README.md
+++ b/README.md
@@ -1,359 +1,68 @@
-# Dime - AI-Powered Content Creation Agent
+# Dime
 
-**AI-powered content creation system for Acts of Defiance**
+A general-purpose AI agent-driven publishing pipeline. Dime researches topics, composes articles, generates graphics, and publishes to a static site through a pluggable adapter pattern.
 
-[![Python 3.13+](https://img.shields.io/badge/python-3.13+-blue.svg)](https://www.python.org/downloads/)
-[![FastAPI](https://img.shields.io/badge/FastAPI-0.104+-green.svg)](https://fastapi.tiangolo.com)
-[![Google ADK](https://img.shields.io/badge/Google_ADK-1.0+-orange.svg)](https://ai.google.dev/adk)
+Dime is not tied to any specific topic or publication. It powers [Acts of Defiance](https://github.com/ActsOfDefiance/acts-of-defiance), but can drive any content pipeline that fits the research-write-illustrate-publish workflow.
 
-Dime is a sophisticated multi-agent content creation system designed for Acts of Defiance, specializing in generating high-quality articles about political liberation movements and historical analysis.
+## Quick start
 
-## 📋 Current Status
-
-**✅ Phase 0: Foundation Complete (Issues #1-4)**
-- ✅ **CLI Interface**: Working `health` and `start` commands
-- ✅ **ADK Web Interface**: Functional web interface at http://localhost:8000
-- ✅ **Agent System**: Basic content creation agents with research and writing tools
-- ✅ **Configuration**: Simplified case-sensitive environment variable management
-- ✅ **Testing Framework**: pytest with 93% code coverage (20 tests passing)
-- ✅ **Code Quality**: PEP 8 compliant, ruff linting and formatting
-
-**📋 Phase 1: Planned (Not Yet Implemented)**
-- Enhanced agent tools and sophisticated workflows
-- Database (PostgreSQL) and Redis integration
-- Full approval workflow interface
-- Production monitoring and observability
-
-## ✨ Features
-
-### 🤖 Multi-Agent System (Phase 0: Basic Implementation)
-**Currently Implemented:**
-- **Research Agent**: Content research and source gathering
-- **Writer Agent**: Article creation from research
-- **Root Agent**: Coordinates research and writing workflows
-- **Interactive ADK Web Interface**: Agent conversations and debugging tools
-
-**Planned for Phase 1:**
-- 7-stage content processing pipeline
-- Human approval workflow with quality gates
-- Intelligent fact-checking with 3-dimensional scoring
-- Automated graphics generation with human selection
-
-### 🎯 Content Focus
-- **Political liberation movements**: Historical and contemporary analysis
-- **Target audience**: Educated 25-40 year olds interested in social justice topics  
-- **Quality standards**: Academic-level research with accessible writing style
-- **Source verification**: Rigorous fact-checking with comprehensive citation tracking
-
-### 🛠️ Technical Architecture
-**Phase 0 Implementation:**
-- **Local-first development**: Runs entirely on your machine
-- **Google ADK integration**: Uses ADK's `get_fast_api_app()` for agent orchestration
-- **FastAPI backend**: Lightweight web framework with ADK integration
-- **Configuration management**: Pydantic Settings with environment variables
-
-**Planned Enhancements:**
-- Web dashboard for monitoring and approval workflow
-- Database (PostgreSQL) for persistence
-- Redis for caching and task queues
-- Cost-optimized design (targeting $50/month budget)
-
-## 🚀 Quick Start
-
-### Prerequisites
-- Python 3.13 or higher
-- Google ADK API key (get from [Google AI Studio](https://aistudio.google.com/))
-- 2GB+ RAM recommended
-
-### Installation
+Prerequisites: Python 3.13+, [uv](https://docs.astral.sh/uv/), PostgreSQL, Redis
 
 ```bash
-# Clone the repository
-git clone https://github.com/ActsOfDefiance/dime.git
+git clone git@github.com:ActsOfDefiance/dime.git
 cd dime
-
-# Set up Python environment
 uv sync
+```
 
-# Configure environment variables
-# Create a .envrc file with required variables:
-# - DATABASE_URL (PostgreSQL connection string)
-# - GOOGLE_ADK_PROJECT_ID (your Google Cloud project ID)
-# - GOOGLE_ADK_API_KEY (your API key)
-# - AUTH_* variables (for production only)
+Configure secrets in `.envrc` (see [dime-ops setup](https://github.com/ActsOfDefiance/dime-ops) for full environment details):
 
-# For development, you can use a minimal .envrc:
-cat > .envrc << 'EOF'
-export DATABASE_URL="postgresql://user:pass@localhost/dime"
-export GOOGLE_ADK_PROJECT_ID="your-project-id"
-export GOOGLE_ADK_API_KEY="your-api-key"
-export AUTH_GOOGLE_OAUTH_CLIENT_ID="placeholder"
-export AUTH_GOOGLE_OAUTH_CLIENT_SECRET="placeholder"
-export AUTH_JWT_SECRET_KEY="dev-secret-key-change-in-production"
-EOF
+```bash
+cp .envrc.example .envrc   # then fill in your keys
+direnv allow
+```
 
-# Load environment (if using direnv, or source manually)
-direnv allow  # or: source .envrc
+Verify everything works:
 
-# Health check - verify configuration
+```bash
 uv run python -m dime health
-
-# Start the ADK web interface
-uv run python -m dime start
 ```
 
-### First Interaction
+## Stack
+
+| Concern | Tool |
+|---|---|
+| Language | Python 3.13 |
+| Package manager | uv |
+| Framework | FastAPI + Google ADK |
+| Database | PostgreSQL + SQLAlchemy + Alembic |
+| Broker | Redis (pluggable) |
+| Linting | ruff |
+| Type checking | pyright |
+| Testing | pytest |
+
+## Architecture
+
+Dime uses a 4-layer architecture with an 11-state content pipeline and 4 ADK agents (Research, Writer, ArtDirector, Image) plus a PublisherAgent. All adapters (broker, filesystem, publishing, notification) are pluggable.
+
+See [dime-ops/docs/specs/](https://github.com/ActsOfDefiance/dime-ops/tree/develop/docs/specs) for full specs:
+- [System overview](https://github.com/ActsOfDefiance/dime-ops/blob/develop/docs/specs/dime-overview.md)
+- [Architecture](https://github.com/ActsOfDefiance/dime-ops/blob/develop/docs/specs/dime-architecture.md)
+- [Pipeline](https://github.com/ActsOfDefiance/dime-ops/blob/develop/docs/specs/dime-pipeline.md)
+- [Data model](https://github.com/ActsOfDefiance/dime-ops/blob/develop/docs/specs/dime-data-model.md)
+- [Agent design](https://github.com/ActsOfDefiance/dime-ops/blob/develop/docs/specs/dime-agents.md)
+
+## Development
 
 ```bash
-# Check system status
-uv run python -m dime health
-
-# Start the web interface (runs on http://localhost:8000)
-uv run python -m dime start
-
-# Custom host/port
-uv run python -m dime start --host 127.0.0.1 --port 3000
+uv run ruff check .          # lint
+uv run ruff format .         # format
+uv run pyright               # type check
+uv run pytest                # test
+uv run pytest --cov          # test with coverage
 ```
 
-**Available Interfaces:**
-- **Main ADK Web UI**: http://localhost:8000/ - Interactive agent conversations
-- **Developer Tools**: http://localhost:8000/dev-ui/ - ADK debugging interface
+All work follows Gitflow: feature branches off `develop`, PRs required to merge.
 
-**What You Can Do:**
-- Start conversations with the dime_agent
-- Test research and writing workflows
-- Inspect agent behavior and tool execution
-- Debug agent configurations
+## License
 
-### Running Tests
-
-```bash
-# Run all tests
-uv run pytest
-
-# Run with coverage
-uv run pytest --cov
-
-# Run with verbose output
-uv run pytest -v
-
-# Run specific test file
-uv run pytest tests/test_config.py
-```
-
-## 📋 Content Workflow
-
-### Phase 0: Current Implementation
-**Basic Agent Interactions:**
-- Interactive conversations with research and writer agents
-- Manual topic input through ADK web interface
-- Basic research and writing workflow coordination
-- Agent debugging and tool inspection
-
-### Planned 7-Stage Pipeline (Phase 1+)
-
-**Stage 1: Topic Selection (Human)**
-- Manual curation of topics based on historical events and mission alignment
-
-**Stage 2: Research Agent**
-- Automated research using Google Gemini models
-- Source gathering and preliminary analysis
-- Citation collection and organization
-
-**Stage 3: Fact Checker Agent (Planned)**
-- Credibility scoring (1-10 scale) for source reliability
-- Bias analysis for political lean and objectivity
-- Claim verification against authoritative sources
-- Quality gate for articles scoring <5 average
-
-**Stage 4: Writer Agent (Enhanced)**
-- Casual, hip, intelligent tone
-- 5-10 paragraphs per article
-- High-credibility source prioritization
-- Citations referencing research footnotes
-
-**Stage 5: Editor Agent (Planned)**
-- Style consistency and voice maintenance
-- Fact validation and citation double-checking
-- Readability optimization for target audience
-- Citation formatting standardization
-
-**Stage 6: Graphics Agent (Planned)**
-- AI-generated header images and thumbnails
-- Multiple option presentation for human selection
-- Visual identity consistency
-- Accessibility with alt text generation
-
-**Stage 7: Assembly Agent (Planned)**
-- Final markdown document compilation
-- Automated Git repository commits
-- Template-based structure
-- Metadata inclusion (scores, processing history)
-
-## 🛡️ Human Oversight (Planned for Phase 1)
-
-**Approval Workflow:**
-- Web dashboard with progress indicators
-- Real-time updates via WebSocket/SSE
-- Approval actions: Accept, reject, edit, feedback
-- Quality tracking and performance metrics
-
-**Review Information:**
-- Complete processing history
-- Confidence scores and validation metrics
-- Processing time and retry counts
-- Audit trail for all approvals
-
-## 💰 Cost Optimization
-
-### Budget-Conscious Design
-- **$50/month target**: Primarily for Google ADK/Gemini API calls
-- **Local development**: No cloud infrastructure costs initially
-- **Aggressive caching**: Reduces redundant API calls
-- **Model optimization**: Right-sized models for each task
-
-### Volume Expectations
-- **Processing capacity**: 1-10 articles per day
-- **Processing time**: <1 hour per article end-to-end
-- **Fail-fast approach**: Quick error detection and human escalation
-
-## 📊 Performance Metrics
-
-### Quality Indicators
-- **Fact-check scores**: Average credibility, bias, and verification ratings
-- **Approval rates**: Human acceptance rate by agent and overall
-- **Processing efficiency**: Time per stage and total article completion
-- **Error rates**: Failed processing attempts and recovery success
-
-### System Health  
-- **Agent performance**: Success rates, processing times, retry frequency
-- **Cost tracking**: Daily/monthly API usage and spend analysis
-- **User engagement**: Approval workflow usage and feedback quality
-
-## 🏗️ Architecture
-
-### Current Technology Stack (Phase 0)
-- **Backend**: FastAPI 0.104+ with Python 3.13+
-- **AI Framework**: Google ADK 1.0+ (Agent Development Kit)
-- **Configuration**: Pydantic Settings with environment variables
-- **Testing**: pytest 8.0+ with pytest-cov for coverage
-- **Code Quality**: ruff 0.8+ for linting and formatting
-- **Package Management**: uv for Python dependencies
-- **Web Server**: uvicorn ASGI server
-
-### Planned Infrastructure (Phase 1+)
-- **Database**: PostgreSQL for persistence
-- **Caching**: Redis for performance and task queues
-- **Frontend**: Web dashboard for approval workflows
-- **Authentication**: OAuth 2.0 with Google login
-- **Monitoring**: Logfire for observability
-
-### Development Approach
-- **Local-first**: Full development environment on local machine
-- **Cloud-ready**: Architecture prepared for Google Cloud deployment
-- **Test-driven**: 90%+ test coverage requirement
-- **Quality-focused**: PEP 8 compliance and comprehensive testing
-
-## 📚 Documentation
-
-### For Developers
-- **[CLAUDE.md](CLAUDE.md)**: AI-assisted development guide for Claude Code
-- **[Project Structure](docs/development/project-structure.md)**: Current codebase organization
-- **[Implementation Plans](docs/development/implementation_plans/)**: Detailed plans for Issues #2 and #4
-- **[Technical Requirements](docs/development/technical-requirements.md)**: Complete system specifications
-- **[Agent Prompts](docs/technical/agent-prompts.md)**: Current agent instruction specifications
-
-### Planning Documentation
-- **[Product Discovery](docs/development/product-discovery-session.md)**: Discovery session results
-- **[Implementation Plan](docs/development/implementation-plan.md)**: 16-week development timeline
-- **[Roadmap](docs/development/roadmap.md)**: Development phases and milestones
-- **[Requirements Analysis](docs/development/requirements-analysis.md)**: Stakeholder needs
-
-### Technical Documentation
-- **[API Reference](docs/technical/api-reference.md)**: ADK API and endpoint documentation
-- **[Architecture](docs/technical/architecture.md)**: System architecture overview
-- **[Settings Usage](docs/technical/settings-usage-examples.md)**: Configuration examples
-
-### GitHub Issues
-- **[GitHub Issues Directory](docs/github_issues/)**: Detailed issue specifications for all project issues
-
-## 🤝 Contributing
-
-### Development Workflow
-1. **Fork** the repository
-2. **Create** a feature branch (`git checkout -b feature/amazing-feature`)
-3. **Commit** your changes (`git commit -m 'feat: add amazing feature'`)
-4. **Push** to the branch (`git push origin feature/amazing-feature`)
-5. **Open** a Pull Request
-
-### Code Quality Standards
-- **Formatting**: `ruff format` for PEP 8 compliance
-- **Linting**: `ruff check` with automatic fixes
-- **Testing**: 90%+ test coverage required (currently 93%)
-- **Documentation**: Comprehensive docstrings and API docs
-- **Commit Policy**: 100% test pass rate before committing
-
-### Getting Started with Development
-```bash
-# Set up development environment
-uv sync
-
-# Run quality checks
-uv run ruff format .     # Auto-format code
-uv run ruff check .      # Lint code
-uv run ruff check --fix .  # Auto-fix linting issues
-
-# Run tests
-uv run pytest            # Run all tests
-uv run pytest --cov      # Run with coverage
-uv run pytest -v         # Verbose output
-```
-
-### Development Commands
-```bash
-# Application commands
-uv run python -m dime health         # Check configuration
-uv run python -m dime start          # Start web server
-uv run python -m dime start --port 3000  # Custom port
-
-# Testing commands
-uv run pytest                        # Run all tests
-uv run pytest tests/test_config.py   # Run specific test
-uv run pytest --cov --cov-report=html  # Coverage report
-
-# Code quality
-uv run ruff format .                 # Format all code
-uv run ruff check .                  # Check for issues
-uv run ruff check --fix .           # Auto-fix issues
-```
-
-## 📄 License
-
-This project is licensed under the MIT License - see the [LICENSE](LICENSE) file for details.
-
-## 🆘 Support
-
-### Getting Help
-- **Documentation**: Comprehensive guides in the `docs/` directory
-- **Issues**: Report bugs and request features via GitHub Issues
-- **CLAUDE.md**: Development guide for AI-assisted development
-
-### Development Support
-- **Setup Guide**: See Quick Start section above for installation
-- **Architecture Questions**: Review [Technical Requirements](docs/development/technical-requirements.md)
-- **API Integration**: Check [API Reference](docs/technical/api-reference.md)
-- **Configuration**: See [Settings Usage Examples](docs/technical/settings-usage-examples.md)
-
-## 🎯 Mission
-
-Dime empowers Acts of Defiance to create high-quality, well-researched content about political liberation movements and social justice topics. By combining AI automation with human oversight, we maintain academic rigor while making complex historical topics accessible to a broader audience.
-
-**Focus areas:**
-- Historical liberation movements and their contemporary relevance
-- Political analysis from a progressive perspective  
-- Educational content that bridges academic research and public understanding
-- Source-verified information with transparent fact-checking
-
----
-
-**Built with ❤️ for social justice and historical education**
+[GPLv3](LICENSE)


### PR DESCRIPTION
## Summary
- Replace bloated Phase 0 README (350 lines) with concise version (80 lines) pointing to dime-ops specs
- Replace outdated CLAUDE.md (229 lines) with lean repo-specific version (90 lines)
- Track .claudeignore
- Add .envrc to .claudeignore to prevent secret exposure

## License note
The old README incorrectly stated MIT. The LICENSE file in this repo has been GPLv3 since creation. The new README correctly references GPLv3.

## Test plan
- [ ] README renders correctly on GitHub
- [ ] CLAUDE.md accurately reflects current file structure and commands
- [ ] No references to old 7-stage pipeline or mypy

🤖 Generated with [Claude Code](https://claude.com/claude-code)