### PR TITLE
Add pluggable adapter layer (Issue #15)

### DIFF
--- a/dime/adapters/__init__.py
+++ b/dime/adapters/__init__.py
@@ -1,0 +1,16 @@
+from dime.adapters.factory import AdapterSet, build_adapters
+from dime.adapters.protocols import (
+    BrokerAdapter,
+    FileSystemAdapter,
+    NotificationAdapter,
+    PublishingAdapter,
+)
+
+__all__ = [
+    "AdapterSet",
+    "BrokerAdapter",
+    "FileSystemAdapter",
+    "NotificationAdapter",
+    "PublishingAdapter",
+    "build_adapters",
+]

--- a/dime/adapters/broker/__init__.py
+++ b/dime/adapters/broker/__init__.py
@@ -1,0 +1,5 @@
+from dime.adapters.broker.gcppubsub import GCPPubSubBrokerAdapter
+from dime.adapters.broker.rabbitmq import RabbitMQBrokerAdapter
+from dime.adapters.broker.redis import RedisBrokerAdapter
+
+__all__ = ["GCPPubSubBrokerAdapter", "RabbitMQBrokerAdapter", "RedisBrokerAdapter"]

--- a/dime/adapters/broker/gcppubsub.py
+++ b/dime/adapters/broker/gcppubsub.py
@@ -1,0 +1,24 @@
+from __future__ import annotations
+
+from collections.abc import Awaitable, Callable
+from typing import Any
+
+
+class GCPPubSubBrokerAdapter:
+    """BrokerAdapter stub for GCP Pub/Sub. Not yet implemented."""
+
+    def __init__(self, project_id: str, topic_prefix: str = "dime") -> None:
+        self._project_id = project_id
+        self._topic_prefix = topic_prefix
+
+    async def dispatch_task(self, task_type: str, payload: dict[str, Any]) -> None:
+        raise NotImplementedError("GCPPubSubBrokerAdapter is not yet implemented")
+
+    async def consume(
+        self,
+        task_type: str,
+        handler: Callable[[dict[str, Any]], Awaitable[None]],
+        max_count: int = 10,
+        block_ms: int = 5000,
+    ) -> None:
+        raise NotImplementedError("GCPPubSubBrokerAdapter is not yet implemented")

--- a/dime/adapters/broker/rabbitmq.py
+++ b/dime/adapters/broker/rabbitmq.py
@@ -1,0 +1,23 @@
+from __future__ import annotations
+
+from collections.abc import Awaitable, Callable
+from typing import Any
+
+
+class RabbitMQBrokerAdapter:
+    """BrokerAdapter stub for RabbitMQ. Not yet implemented."""
+
+    def __init__(self, url: str) -> None:
+        self._url = url
+
+    async def dispatch_task(self, task_type: str, payload: dict[str, Any]) -> None:
+        raise NotImplementedError("RabbitMQBrokerAdapter is not yet implemented")
+
+    async def consume(
+        self,
+        task_type: str,
+        handler: Callable[[dict[str, Any]], Awaitable[None]],
+        max_count: int = 10,
+        block_ms: int = 5000,
+    ) -> None:
+        raise NotImplementedError("RabbitMQBrokerAdapter is not yet implemented")

--- a/dime/adapters/broker/redis.py
+++ b/dime/adapters/broker/redis.py
@@ -1,0 +1,63 @@
+from __future__ import annotations
+
+import json
+import uuid
+from collections.abc import Awaitable, Callable
+from typing import Any
+
+import redis.asyncio as aioredis
+
+
+class RedisBrokerAdapter:
+    """BrokerAdapter implementation using Redis Streams."""
+
+    _GROUP = "dime-workers"
+
+    def __init__(self, url: str) -> None:
+        self._url = url
+        self._client: aioredis.Redis[str] = aioredis.from_url(  # type: ignore[type-arg]
+            url, decode_responses=True
+        )
+
+    def _stream_key(self, task_type: str) -> str:
+        return f"dime:tasks:{task_type}"
+
+    async def _ensure_group(self, stream_key: str) -> None:
+        try:
+            await self._client.xgroup_create(
+                stream_key, self._GROUP, id="0", mkstream=True
+            )
+        except aioredis.ResponseError:
+            pass  # Group already exists
+
+    async def dispatch_task(self, task_type: str, payload: dict[str, Any]) -> None:
+        key = self._stream_key(task_type)
+        await self._client.xadd(key, {"payload": json.dumps(payload)})
+
+    async def consume(
+        self,
+        task_type: str,
+        handler: Callable[[dict[str, Any]], Awaitable[None]],
+        max_count: int = 10,
+        block_ms: int = 5000,
+    ) -> None:
+        key = self._stream_key(task_type)
+        await self._ensure_group(key)
+        consumer_name = f"consumer-{uuid.uuid4().hex[:8]}"
+        messages: list[Any] = await self._client.xreadgroup(  # type: ignore[assignment]
+            self._GROUP,
+            consumer_name,
+            {key: ">"},
+            count=max_count,
+            block=block_ms,
+        )
+        if not messages:
+            return
+        for _stream, entries in messages:
+            for entry_id, data in entries:
+                payload: dict[str, Any] = json.loads(data["payload"])
+                await handler(payload)
+                await self._client.xack(key, self._GROUP, entry_id)
+
+    async def close(self) -> None:
+        await self._client.aclose()

--- a/dime/adapters/factory.py
+++ b/dime/adapters/factory.py
@@ -1,0 +1,45 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from dime.adapters.broker.redis import RedisBrokerAdapter
+from dime.adapters.filesystem.local import LocalFileSystemAdapter
+from dime.adapters.notification.websocket import WebSocketNotificationAdapter
+from dime.adapters.protocols import (
+    BrokerAdapter,
+    FileSystemAdapter,
+    NotificationAdapter,
+    PublishingAdapter,
+)
+from dime.adapters.publishing.hugo import HugoPublishingAdapter
+from dime.config.settings import DimeSettings
+
+
+@dataclass
+class AdapterSet:
+    broker: BrokerAdapter
+    filesystem: FileSystemAdapter
+    publishing: PublishingAdapter
+    notification: NotificationAdapter
+
+
+def build_adapters(settings: DimeSettings) -> AdapterSet:
+    """Construct and return all adapters from application settings.
+
+    No concrete adapter type should be imported outside of this factory
+    or the adapter package itself.
+    """
+    broker: BrokerAdapter = RedisBrokerAdapter(url=str(settings.REDIS_URL))
+    filesystem: FileSystemAdapter = LocalFileSystemAdapter(
+        base_path=settings.STORAGE_BASE_PATH
+    )
+    publishing: PublishingAdapter = HugoPublishingAdapter(
+        content_dir=settings.HUGO_CONTENT_DIR
+    )
+    notification: NotificationAdapter = WebSocketNotificationAdapter()
+    return AdapterSet(
+        broker=broker,
+        filesystem=filesystem,
+        publishing=publishing,
+        notification=notification,
+    )

--- a/dime/adapters/filesystem/__init__.py
+++ b/dime/adapters/filesystem/__init__.py
@@ -1,0 +1,4 @@
+from dime.adapters.filesystem.gcs import GCSFileSystemAdapter
+from dime.adapters.filesystem.local import LocalFileSystemAdapter
+
+__all__ = ["GCSFileSystemAdapter", "LocalFileSystemAdapter"]

--- a/dime/adapters/filesystem/gcs.py
+++ b/dime/adapters/filesystem/gcs.py
@@ -1,0 +1,42 @@
+from __future__ import annotations
+
+from google.cloud import storage  # type: ignore[import-untyped]
+
+
+class GCSFileSystemAdapter:
+    """FileSystemAdapter backed by Google Cloud Storage.
+
+    Used for images only — markdown content always lives on the local filesystem.
+    """
+
+    def __init__(self, bucket_name: str, prefix: str = "") -> None:
+        self._bucket_name = bucket_name
+        self._prefix = prefix.rstrip("/")
+        self._client: storage.Client = storage.Client()  # type: ignore[reportUnknownMemberType]
+        self._bucket = self._client.bucket(bucket_name)  # type: ignore[reportUnknownMemberType]
+
+    def _blob_name(self, path: str) -> str:
+        if self._prefix:
+            return f"{self._prefix}/{path}"
+        return path
+
+    def read(self, path: str) -> str:
+        blob = self._bucket.blob(self._blob_name(path))  # type: ignore[reportUnknownMemberType]
+        return blob.download_as_text(encoding="utf-8")  # type: ignore[reportUnknownMemberType]
+
+    def write(self, path: str, content: str) -> None:
+        blob = self._bucket.blob(self._blob_name(path))  # type: ignore[reportUnknownMemberType]
+        blob.upload_from_string(content, content_type="text/plain; charset=utf-8")  # type: ignore[reportUnknownMemberType]
+
+    def exists(self, path: str) -> bool:
+        blob = self._bucket.blob(self._blob_name(path))  # type: ignore[reportUnknownMemberType]
+        return blob.exists()  # type: ignore[reportUnknownMemberType]
+
+    def list(self, prefix: str) -> list[str]:
+        full_prefix = self._blob_name(prefix) if prefix else self._prefix
+        blobs = self._client.list_blobs(self._bucket_name, prefix=full_prefix)  # type: ignore[reportUnknownMemberType]
+        strip = f"{self._prefix}/" if self._prefix else ""
+        return [
+            b.name[len(strip) :] if strip and b.name.startswith(strip) else b.name  # type: ignore[reportUnknownMemberType,reportUnknownVariableType]
+            for b in blobs  # type: ignore[reportUnknownVariableType]
+        ]

--- a/dime/adapters/filesystem/local.py
+++ b/dime/adapters/filesystem/local.py
@@ -1,0 +1,34 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+
+class LocalFileSystemAdapter:
+    """FileSystemAdapter backed by the local filesystem.
+
+    All paths are relative to base_path (the compendium/ root).
+    """
+
+    def __init__(self, base_path: str) -> None:
+        self._base = Path(base_path)
+        self._base.mkdir(parents=True, exist_ok=True)
+
+    def _resolve(self, path: str) -> Path:
+        return self._base / path
+
+    def read(self, path: str) -> str:
+        return self._resolve(path).read_text(encoding="utf-8")
+
+    def write(self, path: str, content: str) -> None:
+        resolved = self._resolve(path)
+        resolved.parent.mkdir(parents=True, exist_ok=True)
+        resolved.write_text(content, encoding="utf-8")
+
+    def exists(self, path: str) -> bool:
+        return self._resolve(path).exists()
+
+    def list(self, prefix: str) -> list[str]:
+        base = self._resolve(prefix)
+        if not base.exists():
+            return []
+        return [str(p.relative_to(self._base)) for p in base.rglob("*") if p.is_file()]

--- a/dime/adapters/notification/__init__.py
+++ b/dime/adapters/notification/__init__.py
@@ -1,0 +1,3 @@
+from dime.adapters.notification.websocket import WebSocketNotificationAdapter
+
+__all__ = ["WebSocketNotificationAdapter"]

--- a/dime/adapters/notification/websocket.py
+++ b/dime/adapters/notification/websocket.py
@@ -1,0 +1,34 @@
+from __future__ import annotations
+
+import json
+import uuid
+
+from fastapi import WebSocket
+
+
+class WebSocketNotificationAdapter:
+    """NotificationAdapter that pushes events over WebSocket connections.
+
+    Maintains an in-memory registry of active connections keyed by user_id.
+    Always active in solo mode — no external service required.
+    """
+
+    def __init__(self) -> None:
+        self._connections: dict[uuid.UUID, WebSocket] = {}
+
+    def register(self, user_id: uuid.UUID, websocket: WebSocket) -> None:
+        self._connections[user_id] = websocket
+
+    def unregister(self, user_id: uuid.UUID) -> None:
+        self._connections.pop(user_id, None)
+
+    @property
+    def connected_users(self) -> list[uuid.UUID]:
+        return list(self._connections.keys())
+
+    async def notify(self, event: str, user_id: uuid.UUID, message: str) -> None:
+        websocket = self._connections.get(user_id)
+        if websocket is None:
+            return
+        payload = json.dumps({"event": event, "message": message})
+        await websocket.send_text(payload)

--- a/dime/adapters/protocols.py
+++ b/dime/adapters/protocols.py
@@ -1,0 +1,61 @@
+from __future__ import annotations
+
+import uuid
+from collections.abc import Awaitable, Callable
+from typing import Any, Protocol, runtime_checkable
+
+
+@runtime_checkable
+class BrokerAdapter(Protocol):
+    """Task queue and event bus. Implementations: Redis, RabbitMQ, GCP Pub/Sub."""
+
+    async def dispatch_task(self, task_type: str, payload: dict[str, Any]) -> None: ...
+
+    async def consume(
+        self,
+        task_type: str,
+        handler: Callable[[dict[str, Any]], Awaitable[None]],
+        max_count: int = 10,
+        block_ms: int = 5000,
+    ) -> None: ...
+
+
+@runtime_checkable
+class FileSystemAdapter(Protocol):
+    """Abstracts local disk vs. GCS. Sync — agents use thread executor for async contexts."""
+
+    def read(self, path: str) -> str: ...
+
+    def write(self, path: str, content: str) -> None: ...
+
+    def exists(self, path: str) -> bool: ...
+
+    def list(self, prefix: str) -> list[str]: ...
+
+
+@runtime_checkable
+class PublishingAdapter(Protocol):
+    """Signal interface for publishing targets."""
+
+    async def emit(
+        self,
+        article_id: uuid.UUID,
+        content: str,
+        frontmatter: dict[str, Any],
+    ) -> None: ...
+
+    def signal(self) -> None: ...
+
+    def preview_url(self) -> str | None: ...
+
+
+@runtime_checkable
+class NotificationAdapter(Protocol):
+    """Out-of-band notification delivery."""
+
+    async def notify(
+        self,
+        event: str,
+        user_id: uuid.UUID,
+        message: str,
+    ) -> None: ...

--- a/dime/adapters/publishing/__init__.py
+++ b/dime/adapters/publishing/__init__.py
@@ -1,0 +1,3 @@
+from dime.adapters.publishing.hugo import HugoPublishingAdapter
+
+__all__ = ["HugoPublishingAdapter"]

--- a/dime/adapters/publishing/hugo.py
+++ b/dime/adapters/publishing/hugo.py
@@ -1,0 +1,38 @@
+from __future__ import annotations
+
+import json
+import uuid
+from pathlib import Path
+from typing import Any
+
+
+class HugoPublishingAdapter:
+    """PublishingAdapter that writes content to a Hugo site content directory.
+
+    Emits a markdown file with JSON frontmatter and touches a signal file
+    to trigger a Hugo rebuild watcher.
+    """
+
+    _SIGNAL_FILE = ".rebuild-signal"
+
+    def __init__(self, content_dir: str) -> None:
+        self._content_dir = Path(content_dir)
+        self._content_dir.mkdir(parents=True, exist_ok=True)
+
+    async def emit(
+        self,
+        article_id: uuid.UUID,
+        content: str,
+        frontmatter: dict[str, Any],
+    ) -> None:
+        fm_json = json.dumps(frontmatter, indent=2, default=str)
+        doc = f"{fm_json}\n\n{content}"
+        dest = self._content_dir / f"{article_id}.md"
+        dest.write_text(doc, encoding="utf-8")
+
+    def signal(self) -> None:
+        signal_path = self._content_dir / self._SIGNAL_FILE
+        signal_path.touch()
+
+    def preview_url(self) -> str | None:
+        return None

--- a/dime/config/settings.py
+++ b/dime/config/settings.py
@@ -128,6 +128,11 @@ class DimeSettings(BaseSettings):
     STORAGE_EXPORTS_PATH: str = "./storage/exports"
     STORAGE_MAX_FILE_SIZE_MB: int = 50
 
+    # ==========================================================================
+    # Publishing Configuration
+    # ==========================================================================
+    HUGO_CONTENT_DIR: str = "./hugo-content"
+
     def __init__(self, **kwargs: Any) -> None:
         """Initialize settings with environment validation."""
         super().__init__(**kwargs)  # pyright: ignore[reportUnknownArgumentType]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -28,6 +28,7 @@ def test_env() -> Generator[dict[str, str], None, None]:
         "AUTH_JWT_SECRET_KEY": "test-jwt-secret",
         "APP_ENVIRONMENT": "development",
         "LOGFIRE_TOKEN": "",  # Disable Logfire in tests
+        "HUGO_CONTENT_DIR": "/tmp/test-hugo-content",
     }
 
     # Set test environment variables

--- a/tests/test_adapters.py
+++ b/tests/test_adapters.py
@@ -1,0 +1,402 @@
+"""
+Tests for pluggable adapters.
+
+Unit tests (default run): protocol compliance, local FS, Hugo, WebSocket,
+stubs, factory construction, adapter constructors.
+
+Integration tests (@pytest.mark.integration): real Redis round-trip,
+GCS instantiation (skipped unless GCS_TEST_BUCKET env var is set).
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import uuid
+from pathlib import Path
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from dime.adapters.broker.gcppubsub import GCPPubSubBrokerAdapter
+from dime.adapters.broker.rabbitmq import RabbitMQBrokerAdapter
+from dime.adapters.broker.redis import RedisBrokerAdapter
+from dime.adapters.factory import AdapterSet, build_adapters
+from dime.adapters.filesystem.gcs import GCSFileSystemAdapter
+from dime.adapters.filesystem.local import LocalFileSystemAdapter
+from dime.adapters.notification.websocket import WebSocketNotificationAdapter
+from dime.adapters.protocols import (
+    BrokerAdapter,
+    FileSystemAdapter,
+    NotificationAdapter,
+    PublishingAdapter,
+)
+from dime.adapters.publishing.hugo import HugoPublishingAdapter
+from dime.config.settings import reload_settings
+
+
+# ---------------------------------------------------------------------------
+# Protocol compliance
+# ---------------------------------------------------------------------------
+
+
+class TestProtocolCompliance:
+    def test_redis_broker_is_broker_adapter(self) -> None:
+        with patch("redis.asyncio.from_url"):
+            adapter = RedisBrokerAdapter(url="redis://localhost:6379/0")
+        assert isinstance(adapter, BrokerAdapter)
+
+    def test_local_fs_is_filesystem_adapter(self, tmp_path: Path) -> None:
+        adapter = LocalFileSystemAdapter(base_path=str(tmp_path))
+        assert isinstance(adapter, FileSystemAdapter)
+
+    def test_hugo_is_publishing_adapter(self, tmp_path: Path) -> None:
+        adapter = HugoPublishingAdapter(content_dir=str(tmp_path))
+        assert isinstance(adapter, PublishingAdapter)
+
+    def test_websocket_is_notification_adapter(self) -> None:
+        adapter = WebSocketNotificationAdapter()
+        assert isinstance(adapter, NotificationAdapter)
+
+
+# ---------------------------------------------------------------------------
+# RedisBrokerAdapter (unit — no live Redis)
+# ---------------------------------------------------------------------------
+
+
+class TestRedisBrokerAdapterUnit:
+    def test_stream_key_format(self) -> None:
+        with patch("redis.asyncio.from_url"):
+            adapter = RedisBrokerAdapter(url="redis://localhost:6379/0")
+        assert adapter._stream_key("research") == "dime:tasks:research"  # type: ignore[reportPrivateUsage]
+
+    def test_stream_key_different_types(self) -> None:
+        with patch("redis.asyncio.from_url"):
+            adapter = RedisBrokerAdapter(url="redis://localhost:6379/0")
+        assert adapter._stream_key("write") == "dime:tasks:write"  # type: ignore[reportPrivateUsage]
+        assert adapter._stream_key("publish") == "dime:tasks:publish"  # type: ignore[reportPrivateUsage]
+
+    def test_stores_url(self) -> None:
+        url = "redis://testhost:6379/2"
+        with patch("redis.asyncio.from_url"):
+            adapter = RedisBrokerAdapter(url=url)
+        assert adapter._url == url  # type: ignore[reportPrivateUsage]
+
+
+# ---------------------------------------------------------------------------
+# BrokerAdapter stubs
+# ---------------------------------------------------------------------------
+
+
+class TestBrokerStubs:
+    @pytest.mark.asyncio
+    async def test_rabbitmq_dispatch_raises(self) -> None:
+        adapter = RabbitMQBrokerAdapter(url="amqp://localhost")
+        with pytest.raises(NotImplementedError):
+            await adapter.dispatch_task("test", {})
+
+    @pytest.mark.asyncio
+    async def test_rabbitmq_consume_raises(self) -> None:
+        adapter = RabbitMQBrokerAdapter(url="amqp://localhost")
+        with pytest.raises(NotImplementedError):
+            await adapter.consume("test", AsyncMock())
+
+    @pytest.mark.asyncio
+    async def test_gcppubsub_dispatch_raises(self) -> None:
+        adapter = GCPPubSubBrokerAdapter(project_id="test-project")
+        with pytest.raises(NotImplementedError):
+            await adapter.dispatch_task("test", {})
+
+    @pytest.mark.asyncio
+    async def test_gcppubsub_consume_raises(self) -> None:
+        adapter = GCPPubSubBrokerAdapter(project_id="test-project")
+        with pytest.raises(NotImplementedError):
+            await adapter.consume("test", AsyncMock())
+
+    def test_gcppubsub_stores_config(self) -> None:
+        adapter = GCPPubSubBrokerAdapter(project_id="my-proj", topic_prefix="myapp")
+        assert adapter._project_id == "my-proj"  # type: ignore[reportPrivateUsage]
+        assert adapter._topic_prefix == "myapp"  # type: ignore[reportPrivateUsage]
+
+    def test_rabbitmq_stores_url(self) -> None:
+        adapter = RabbitMQBrokerAdapter(url="amqp://user:pass@host/vhost")
+        assert adapter._url == "amqp://user:pass@host/vhost"  # type: ignore[reportPrivateUsage]
+
+
+# ---------------------------------------------------------------------------
+# LocalFileSystemAdapter
+# ---------------------------------------------------------------------------
+
+
+class TestLocalFileSystemAdapter:
+    def test_write_and_read(self, tmp_path: Path) -> None:
+        adapter = LocalFileSystemAdapter(base_path=str(tmp_path))
+        adapter.write("articles/test.md", "# Hello")
+        assert adapter.read("articles/test.md") == "# Hello"
+
+    def test_exists_true(self, tmp_path: Path) -> None:
+        adapter = LocalFileSystemAdapter(base_path=str(tmp_path))
+        adapter.write("file.txt", "content")
+        assert adapter.exists("file.txt") is True
+
+    def test_exists_false(self, tmp_path: Path) -> None:
+        adapter = LocalFileSystemAdapter(base_path=str(tmp_path))
+        assert adapter.exists("nonexistent.txt") is False
+
+    def test_list_returns_files(self, tmp_path: Path) -> None:
+        adapter = LocalFileSystemAdapter(base_path=str(tmp_path))
+        adapter.write("subdir/a.md", "a")
+        adapter.write("subdir/b.md", "b")
+        files = adapter.list("subdir")
+        assert len(files) == 2
+        assert all(f.startswith("subdir/") for f in files)
+
+    def test_list_empty_prefix(self, tmp_path: Path) -> None:
+        adapter = LocalFileSystemAdapter(base_path=str(tmp_path))
+        result = adapter.list("nonexistent")
+        assert result == []
+
+    def test_write_creates_nested_dirs(self, tmp_path: Path) -> None:
+        adapter = LocalFileSystemAdapter(base_path=str(tmp_path))
+        adapter.write("deep/nested/dir/file.txt", "hello")
+        assert adapter.exists("deep/nested/dir/file.txt")
+
+    def test_base_dir_created_on_init(self, tmp_path: Path) -> None:
+        new_dir = str(tmp_path / "new_base")
+        adapter = LocalFileSystemAdapter(base_path=new_dir)
+        assert Path(new_dir).exists()
+        assert adapter._base == Path(new_dir)  # type: ignore[reportPrivateUsage]
+
+
+# ---------------------------------------------------------------------------
+# GCSFileSystemAdapter (unit — mocked client)
+# ---------------------------------------------------------------------------
+
+
+class TestGCSFileSystemAdapterUnit:
+    def _make_adapter(
+        self, bucket_name: str = "test-bucket", prefix: str = ""
+    ) -> GCSFileSystemAdapter:
+        with patch("google.cloud.storage.Client") as mock_client_cls:
+            mock_client = MagicMock()
+            mock_client_cls.return_value = mock_client
+            mock_client.bucket.return_value = MagicMock()
+            adapter = GCSFileSystemAdapter(bucket_name=bucket_name, prefix=prefix)
+            adapter._client = mock_client  # type: ignore[reportPrivateUsage]
+            return adapter
+
+    def test_blob_name_no_prefix(self) -> None:
+        adapter = self._make_adapter(prefix="")
+        assert adapter._blob_name("art/hero.jpg") == "art/hero.jpg"  # type: ignore[reportPrivateUsage]
+
+    def test_blob_name_with_prefix(self) -> None:
+        adapter = self._make_adapter(prefix="images")
+        assert adapter._blob_name("hero.jpg") == "images/hero.jpg"  # type: ignore[reportPrivateUsage]
+
+    def test_stores_bucket_name(self) -> None:
+        adapter = self._make_adapter(bucket_name="my-bucket")
+        assert adapter._bucket_name == "my-bucket"  # type: ignore[reportPrivateUsage]
+
+
+# ---------------------------------------------------------------------------
+# HugoPublishingAdapter
+# ---------------------------------------------------------------------------
+
+
+class TestHugoPublishingAdapter:
+    @pytest.mark.asyncio
+    async def test_emit_creates_file(self, tmp_path: Path) -> None:
+        adapter = HugoPublishingAdapter(content_dir=str(tmp_path))
+        article_id = uuid.uuid4()
+        await adapter.emit(
+            article_id=article_id,
+            content="## Body text",
+            frontmatter={"title": "Test Article", "draft": False},
+        )
+        dest = tmp_path / f"{article_id}.md"
+        assert dest.exists()
+
+    @pytest.mark.asyncio
+    async def test_emit_includes_frontmatter(self, tmp_path: Path) -> None:
+        adapter = HugoPublishingAdapter(content_dir=str(tmp_path))
+        article_id = uuid.uuid4()
+        await adapter.emit(
+            article_id=article_id,
+            content="body",
+            frontmatter={"title": "My Title"},
+        )
+        content = (tmp_path / f"{article_id}.md").read_text()
+        assert "My Title" in content
+        assert "body" in content
+
+    @pytest.mark.asyncio
+    async def test_emit_valid_json_frontmatter(self, tmp_path: Path) -> None:
+        adapter = HugoPublishingAdapter(content_dir=str(tmp_path))
+        article_id = uuid.uuid4()
+        fm = {"title": "T", "tags": ["a", "b"], "draft": True}
+        await adapter.emit(article_id=article_id, content="x", frontmatter=fm)
+        raw = (tmp_path / f"{article_id}.md").read_text()
+        json_part = raw.split("\n\n")[0]
+        parsed = json.loads(json_part)
+        assert parsed["title"] == "T"
+        assert parsed["tags"] == ["a", "b"]
+
+    def test_signal_creates_file(self, tmp_path: Path) -> None:
+        adapter = HugoPublishingAdapter(content_dir=str(tmp_path))
+        adapter.signal()
+        assert (tmp_path / ".rebuild-signal").exists()
+
+    def test_preview_url_returns_none(self, tmp_path: Path) -> None:
+        adapter = HugoPublishingAdapter(content_dir=str(tmp_path))
+        assert adapter.preview_url() is None
+
+    def test_content_dir_created_on_init(self, tmp_path: Path) -> None:
+        new_dir = str(tmp_path / "hugo" / "content")
+        adapter = HugoPublishingAdapter(content_dir=new_dir)
+        assert Path(new_dir).exists()
+        assert adapter._content_dir == Path(new_dir)  # type: ignore[reportPrivateUsage]
+
+
+# ---------------------------------------------------------------------------
+# WebSocketNotificationAdapter
+# ---------------------------------------------------------------------------
+
+
+class TestWebSocketNotificationAdapter:
+    def test_initially_no_connections(self) -> None:
+        adapter = WebSocketNotificationAdapter()
+        assert adapter.connected_users == []
+
+    def test_register_adds_connection(self) -> None:
+        adapter = WebSocketNotificationAdapter()
+        user_id = uuid.uuid4()
+        ws = MagicMock()
+        adapter.register(user_id, ws)
+        assert user_id in adapter.connected_users
+
+    def test_unregister_removes_connection(self) -> None:
+        adapter = WebSocketNotificationAdapter()
+        user_id = uuid.uuid4()
+        ws = MagicMock()
+        adapter.register(user_id, ws)
+        adapter.unregister(user_id)
+        assert user_id not in adapter.connected_users
+
+    def test_unregister_nonexistent_is_noop(self) -> None:
+        adapter = WebSocketNotificationAdapter()
+        adapter.unregister(uuid.uuid4())  # should not raise
+
+    @pytest.mark.asyncio
+    async def test_notify_sends_to_connected_user(self) -> None:
+        adapter = WebSocketNotificationAdapter()
+        user_id = uuid.uuid4()
+        ws = AsyncMock()
+        adapter.register(user_id, ws)
+        await adapter.notify("draft_ready", user_id, "Your draft is ready")
+        ws.send_text.assert_called_once()
+        sent = ws.send_text.call_args[0][0]
+        payload = json.loads(sent)
+        assert payload["event"] == "draft_ready"
+        assert payload["message"] == "Your draft is ready"
+
+    @pytest.mark.asyncio
+    async def test_notify_unknown_user_is_noop(self) -> None:
+        adapter = WebSocketNotificationAdapter()
+        await adapter.notify("event", uuid.uuid4(), "msg")
+
+    @pytest.mark.asyncio
+    async def test_notify_only_sends_to_target_user(self) -> None:
+        adapter = WebSocketNotificationAdapter()
+        user1, user2 = uuid.uuid4(), uuid.uuid4()
+        ws1, ws2 = AsyncMock(), AsyncMock()
+        adapter.register(user1, ws1)
+        adapter.register(user2, ws2)
+        await adapter.notify("event", user1, "msg")
+        ws1.send_text.assert_called_once()
+        ws2.send_text.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# AdapterSet factory
+# ---------------------------------------------------------------------------
+
+
+class TestAdapterFactory:
+    def test_build_adapters_returns_adapter_set(self, test_env: Any) -> None:
+        settings = reload_settings()
+        with patch("redis.asyncio.from_url"):
+            result = build_adapters(settings)
+        assert isinstance(result, AdapterSet)
+
+    def test_build_adapters_broker_is_redis(self, test_env: Any) -> None:
+        settings = reload_settings()
+        with patch("redis.asyncio.from_url"):
+            result = build_adapters(settings)
+        assert isinstance(result.broker, RedisBrokerAdapter)
+
+    def test_build_adapters_filesystem_is_local(self, test_env: Any) -> None:
+        settings = reload_settings()
+        with patch("redis.asyncio.from_url"):
+            result = build_adapters(settings)
+        assert isinstance(result.filesystem, LocalFileSystemAdapter)
+
+    def test_build_adapters_publishing_is_hugo(self, test_env: Any) -> None:
+        settings = reload_settings()
+        with patch("redis.asyncio.from_url"):
+            result = build_adapters(settings)
+        assert isinstance(result.publishing, HugoPublishingAdapter)
+
+    def test_build_adapters_notification_is_websocket(self, test_env: Any) -> None:
+        settings = reload_settings()
+        with patch("redis.asyncio.from_url"):
+            result = build_adapters(settings)
+        assert isinstance(result.notification, WebSocketNotificationAdapter)
+
+
+# ---------------------------------------------------------------------------
+# Integration: Redis round-trip (real Redis required)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.integration
+class TestRedisBrokerIntegration:
+    @pytest.mark.asyncio
+    async def test_dispatch_consume_round_trip(self) -> None:
+        from dime.config.settings import get_settings
+
+        settings = get_settings()
+        adapter = RedisBrokerAdapter(url=str(settings.REDIS_URL))
+        task_type = f"test-{uuid.uuid4().hex[:8]}"
+        sent_payload: dict[str, Any] = {"key": "value", "num": 42}
+
+        await adapter.dispatch_task(task_type, sent_payload)
+
+        received: list[dict[str, Any]] = []
+
+        async def handler(payload: dict[str, Any]) -> None:
+            received.append(payload)
+
+        await adapter.consume(task_type, handler, max_count=1, block_ms=2000)
+        await adapter.close()
+
+        assert len(received) == 1
+        assert received[0] == sent_payload
+
+
+# ---------------------------------------------------------------------------
+# Integration: GCS (skipped unless GCS_TEST_BUCKET is set)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.integration
+class TestGCSFileSystemIntegration:
+    @pytest.fixture(autouse=True)
+    def require_gcs_bucket(self) -> None:
+        if not os.environ.get("GCS_TEST_BUCKET"):
+            pytest.skip("GCS_TEST_BUCKET env var not set")
+
+    def test_gcs_instantiation(self) -> None:
+        bucket = os.environ["GCS_TEST_BUCKET"]
+        adapter = GCSFileSystemAdapter(bucket_name=bucket, prefix="dime-test")
+        assert adapter._bucket_name == bucket  # type: ignore[reportPrivateUsage]


### PR DESCRIPTION
## Summary
- Implements four Protocol-based adapter interfaces (`BrokerAdapter`, `FileSystemAdapter`, `PublishingAdapter`, `NotificationAdapter`) using `typing.Protocol` with `@runtime_checkable`
- Concrete implementations: Redis Streams broker, local filesystem, GCS filesystem, Hugo publishing (JSON frontmatter), WebSocket notifications
- `build_adapters(settings) -> AdapterSet` factory wires everything together from `DimeSettings`

## Changes
- `dime/adapters/protocols.py` — 4 runtime-checkable Protocol definitions
- `dime/adapters/broker/` — RedisBrokerAdapter (XADD/XREADGROUP/XACK), RabbitMQ + GCPPubSub stubs
- `dime/adapters/filesystem/` — LocalFileSystemAdapter (pathlib), GCSFileSystemAdapter
- `dime/adapters/publishing/hugo.py` — HugoPublishingAdapter with JSON frontmatter + rebuild signal
- `dime/adapters/notification/websocket.py` — WebSocketNotificationAdapter with in-memory registry
- `dime/adapters/factory.py` — AdapterSet dataclass + build_adapters()
- `dime/config/settings.py` — added `HUGO_CONTENT_DIR` field
- `tests/test_adapters.py` — 41 unit tests; integration tests behind `@pytest.mark.integration`

## Testing
- [x] All 94 tests pass
- [x] Coverage: 93.71% (target: 90%+)
- [x] All quality checks pass (ruff, pyright — 0 new errors in adapter files)
- [x] Redis integration test present (`@pytest.mark.integration`, excluded from default run)
- [x] GCS integration test skips unless `GCS_TEST_BUCKET` env var is set

## Verification Steps
```bash
uv sync
uv run pytest
uv run pytest -m integration  # requires live Redis
```

## Checklist
- [x] Code follows dime conventions (CLAUDE.md)
- [x] Specs consulted (docs/specs/)
- [x] No secrets committed
- [x] Adapter protocols are `@runtime_checkable` for `isinstance()` checks

Closes #15