### PR TITLE
Implement ADK agents with tool factories and runner (Issue #18)

### DIFF
--- a/dime/agents/art_director.py
+++ b/dime/agents/art_director.py
@@ -5,16 +5,31 @@ Creates image generation prompts for each image slot based on the approved
 article draft and the project's style guide.
 """
 
-from .base import DimeBaseAgent
-from .prompts import ART_DIRECTOR_PROMPT
+from __future__ import annotations
+
+from typing import Any
+
+from dime.agents.base import DimeBaseAgent
+from dime.agents.prompts import ART_DIRECTOR_PROMPT
 
 
 class ArtDirectorAgent(DimeBaseAgent):
     """Agent that produces art_brief.md with per-slot image prompts."""
 
-    def __init__(self) -> None:
+    def __init__(
+        self,
+        tools: list[Any] | None = None,
+        content_guide: dict[str, Any] | None = None,
+        style_guide: dict[str, Any] | None = None,
+    ) -> None:
+        instruction = ART_DIRECTOR_PROMPT + self.format_guide_context(
+            content_guide=content_guide,
+            style_guide=style_guide,
+        )
+
         super().__init__(
             name="art_director",
             model="gemini-2.5-flash",
-            instruction=ART_DIRECTOR_PROMPT,
+            instruction=instruction,
+            tools=tools,
         )

--- a/dime/agents/base.py
+++ b/dime/agents/base.py
@@ -4,7 +4,11 @@ Base Agent Classes
 Common functionality and base classes for Dime agents.
 """
 
-from typing import Dict, Any
+from __future__ import annotations
+
+import json
+from typing import Any
+
 from google.adk.agents import LlmAgent
 
 
@@ -16,12 +20,19 @@ class DimeBaseAgent(LlmAgent):
         name: str,
         model: str = "gemini-2.5-flash",
         instruction: str = "",
+        tools: list[Any] | None = None,
         **kwargs: Any,
     ) -> None:
         """Initialize base agent with common settings."""
-        super().__init__(name=name, model=model, instruction=instruction, **kwargs)  # pyright: ignore[reportUnknownMemberType]
+        super().__init__(  # pyright: ignore[reportUnknownMemberType]
+            name=name,
+            model=model,
+            instruction=instruction,
+            tools=tools or [],
+            **kwargs,
+        )
 
-    def get_agent_info(self) -> Dict[str, Any]:
+    def get_agent_info(self) -> dict[str, Any]:
         """Get agent information for debugging and monitoring."""
         return {
             "name": self.name,
@@ -29,3 +40,30 @@ class DimeBaseAgent(LlmAgent):
             "type": self.__class__.__name__,
             "status": "active",
         }
+
+    @staticmethod
+    def format_guide_context(
+        content_guide: dict[str, Any] | None = None,
+        style_guide: dict[str, Any] | None = None,
+    ) -> str:
+        """Format content_guide and/or style_guide as context to append to instructions.
+
+        Args:
+            content_guide: The project's content guide (audience, voice, standards).
+            style_guide: The project's style guide (image slots, visual tokens).
+
+        Returns:
+            A formatted string to append to the agent's instruction.
+        """
+        parts: list[str] = []
+        if content_guide:
+            parts.append(
+                "\n\n---\n## Content Guide (from project configuration)\n\n"
+                f"```json\n{json.dumps(content_guide, indent=2)}\n```"
+            )
+        if style_guide:
+            parts.append(
+                "\n\n---\n## Style Guide (from project configuration)\n\n"
+                f"```json\n{json.dumps(style_guide, indent=2)}\n```"
+            )
+        return "".join(parts)

--- a/dime/agents/image.py
+++ b/dime/agents/image.py
@@ -5,14 +5,29 @@ Generates image variants for a single image slot using the approved prompt
 and slot specification.
 """
 
-from .base import DimeBaseAgent
-from .prompts import IMAGE_PROMPT
+from __future__ import annotations
+
+from typing import Any
+
+from dime.agents.base import DimeBaseAgent
+from dime.agents.prompts import IMAGE_PROMPT
 
 
 class ImageAgent(DimeBaseAgent):
     """Agent that generates image variants for an image slot."""
 
-    def __init__(self) -> None:
+    def __init__(
+        self,
+        tools: list[Any] | None = None,
+        style_guide: dict[str, Any] | None = None,
+    ) -> None:
+        instruction = IMAGE_PROMPT + self.format_guide_context(
+            style_guide=style_guide,
+        )
+
         super().__init__(
-            name="image", model="gemini-2.5-flash", instruction=IMAGE_PROMPT
+            name="image",
+            model="gemini-2.5-flash",
+            instruction=instruction,
+            tools=tools,
         )

--- a/dime/agents/publisher.py
+++ b/dime/agents/publisher.py
@@ -2,29 +2,73 @@
 Publisher Agent
 
 Coordinates the publishing step. Unlike other agents, this is not an LLM
-agent — it calls the PublishingAdapter and records the publish event.
-The LlmAgent base is retained for ADK compatibility.
+agent — it calls the PublishingAdapter directly and records the publish event.
 """
 
+from __future__ import annotations
+
+import logging
+import uuid
 from typing import Any
 
-from .base import DimeBaseAgent
+from dime.adapters.protocols import FileSystemAdapter, PublishingAdapter
+
+logger = logging.getLogger(__name__)
 
 
-class PublisherAgent(DimeBaseAgent):
-    """Agent that coordinates publishing via the PublishingAdapter."""
+class PublisherAgent:
+    """Non-LLM agent that publishes articles via the PublishingAdapter.
 
-    def __init__(self, sub_agents: list[Any] | None = None) -> None:
-        instruction = (
-            "You are the publishing coordinator. Your role is to publish "
-            "approved articles using the configured publishing adapter and "
-            "record the publish event."
+    This agent is deterministic — no LLM calls. It reads the final article
+    from the filesystem, calls the PublishingAdapter to emit content, and
+    signals a rebuild.
+    """
+
+    def __init__(
+        self,
+        publishing: PublishingAdapter,
+        filesystem: FileSystemAdapter,
+    ) -> None:
+        self._publishing = publishing
+        self._filesystem = filesystem
+
+    async def publish(
+        self,
+        article_id: uuid.UUID,
+        article_slug: str,
+        frontmatter: dict[str, Any],
+    ) -> str:
+        """Publish an article by reading its draft and emitting via the adapter.
+
+        Args:
+            article_id: The article's UUID.
+            article_slug: The article's URL slug (used to locate files).
+            frontmatter: Metadata dict for the publishing target.
+
+        Returns:
+            The preview URL if available, or a confirmation message.
+        """
+        draft_path = f"{article_slug}/draft.md"
+
+        if not self._filesystem.exists(draft_path):
+            msg = f"Cannot publish: draft not found at '{draft_path}'"
+            logger.error(msg)
+            raise FileNotFoundError(msg)
+
+        content = self._filesystem.read(draft_path)
+
+        await self._publishing.emit(
+            article_id=article_id,
+            content=content,
+            frontmatter=frontmatter,
         )
 
-        super().__init__(
-            name="publisher",
-            model="gemini-2.5-flash",
-            instruction=instruction,
-            description="Agent that coordinates article publishing",
-            sub_agents=sub_agents or [],
-        )
+        self._publishing.signal()
+
+        preview_url = self._publishing.preview_url()
+        if preview_url:
+            logger.info("Published article %s — preview: %s", article_id, preview_url)
+            return preview_url
+
+        logger.info("Published article %s", article_id)
+        return f"Article {article_id} published successfully."

--- a/dime/agents/researcher.py
+++ b/dime/agents/researcher.py
@@ -1,18 +1,34 @@
 """
-Research Agent
+Researcher Agent
 
-Conducts web research on a given topic and produces structured research notes.
-Context (content_guide) is injected at runtime by the worker layer.
+Conducts web research on a given topic and produces structured research
+notes in markdown. Context (content_guide) is injected at runtime by
+the worker layer.
 """
 
-from .base import DimeBaseAgent
-from .prompts import RESEARCH_PROMPT
+from __future__ import annotations
+
+from typing import Any
+
+from dime.agents.base import DimeBaseAgent
+from dime.agents.prompts import RESEARCH_PROMPT
 
 
 class ResearcherAgent(DimeBaseAgent):
-    """Agent that conducts web research and produces structured research.md."""
+    """Agent that conducts web research and produces research.md."""
 
-    def __init__(self) -> None:
+    def __init__(
+        self,
+        tools: list[Any] | None = None,
+        content_guide: dict[str, Any] | None = None,
+    ) -> None:
+        instruction = RESEARCH_PROMPT + self.format_guide_context(
+            content_guide=content_guide,
+        )
+
         super().__init__(
-            name="researcher", model="gemini-2.5-flash", instruction=RESEARCH_PROMPT
+            name="researcher",
+            model="gemini-2.5-flash",
+            instruction=instruction,
+            tools=tools,
         )

--- a/dime/agents/runner.py
+++ b/dime/agents/runner.py
@@ -1,0 +1,76 @@
+"""
+Agent runner helper.
+
+Thin wrapper around ADK's Runner + InMemorySessionService that executes
+an agent with a single input message and returns the final text output.
+"""
+
+from __future__ import annotations
+
+import logging
+
+from google.adk.agents import LlmAgent
+from google.adk.runners import Runner
+from google.adk.sessions import InMemorySessionService
+from google.genai import types
+
+logger = logging.getLogger(__name__)
+
+APP_NAME = "dime"
+USER_ID = "worker"
+
+
+async def run_agent(agent: LlmAgent, input_text: str) -> str:
+    """Run an agent with a single input message and return its text output.
+
+    Args:
+        agent: A configured LlmAgent instance (with tools and instruction).
+        input_text: The user message to send to the agent.
+
+    Returns:
+        The agent's final text response. Returns empty string if no text
+        was produced.
+
+    Raises:
+        RuntimeError: If the agent execution fails entirely.
+    """
+    session_service = InMemorySessionService()
+    runner = Runner(
+        agent=agent,
+        app_name=APP_NAME,
+        session_service=session_service,
+    )
+
+    session = await session_service.create_session(
+        app_name=APP_NAME,
+        user_id=USER_ID,
+    )
+
+    content = types.Content(
+        role="user",
+        parts=[types.Part(text=input_text)],
+    )
+
+    final_text = ""
+    async for event in runner.run_async(  # pyright: ignore[reportUnknownMemberType]
+        user_id=USER_ID,
+        session_id=session.id,
+        new_message=content,
+    ):
+        if (
+            event.content
+            and event.content.parts
+            and hasattr(event, "is_final_response")
+            and callable(event.is_final_response)
+            and event.is_final_response()
+        ):
+            for part in event.content.parts:
+                if hasattr(part, "text") and part.text:
+                    final_text += part.text
+
+    if not final_text:
+        # Fallback: collect any text from any event if is_final_response
+        # was not available (ADK version differences).
+        logger.warning("No final response detected — collecting all text events")
+
+    return final_text

--- a/dime/agents/runner.py
+++ b/dime/agents/runner.py
@@ -52,25 +52,28 @@ async def run_agent(agent: LlmAgent, input_text: str) -> str:
     )
 
     final_text = ""
+    fallback_parts: list[str] = []
     async for event in runner.run_async(  # pyright: ignore[reportUnknownMemberType]
         user_id=USER_ID,
         session_id=session.id,
         new_message=content,
     ):
-        if (
-            event.content
-            and event.content.parts
-            and hasattr(event, "is_final_response")
-            and callable(event.is_final_response)
-            and event.is_final_response()
-        ):
-            for part in event.content.parts:
-                if hasattr(part, "text") and part.text:
-                    final_text += part.text
+        if event.content and event.content.parts:
+            event_text = "".join(
+                p.text for p in event.content.parts if hasattr(p, "text") and p.text
+            )
+            if event_text:
+                fallback_parts.append(event_text)
 
-    if not final_text:
-        # Fallback: collect any text from any event if is_final_response
-        # was not available (ADK version differences).
+            if (
+                hasattr(event, "is_final_response")
+                and callable(event.is_final_response)
+                and event.is_final_response()
+            ):
+                final_text += event_text
+
+    if not final_text and fallback_parts:
         logger.warning("No final response detected — collecting all text events")
+        final_text = "".join(fallback_parts)
 
     return final_text

--- a/dime/agents/runner.py
+++ b/dime/agents/runner.py
@@ -34,43 +34,47 @@ async def run_agent(agent: LlmAgent, input_text: str) -> str:
     Raises:
         RuntimeError: If the agent execution fails entirely.
     """
-    session_service = InMemorySessionService()
-    runner = Runner(
-        agent=agent,
-        app_name=APP_NAME,
-        session_service=session_service,
-    )
+    try:
+        session_service = InMemorySessionService()
+        runner = Runner(
+            agent=agent,
+            app_name=APP_NAME,
+            session_service=session_service,
+        )
 
-    session = await session_service.create_session(
-        app_name=APP_NAME,
-        user_id=USER_ID,
-    )
+        session = await session_service.create_session(
+            app_name=APP_NAME,
+            user_id=USER_ID,
+        )
 
-    content = types.Content(
-        role="user",
-        parts=[types.Part(text=input_text)],
-    )
+        content = types.Content(
+            role="user",
+            parts=[types.Part(text=input_text)],
+        )
 
-    final_text = ""
-    fallback_parts: list[str] = []
-    async for event in runner.run_async(  # pyright: ignore[reportUnknownMemberType]
-        user_id=USER_ID,
-        session_id=session.id,
-        new_message=content,
-    ):
-        if event.content and event.content.parts:
-            event_text = "".join(
-                p.text for p in event.content.parts if hasattr(p, "text") and p.text
-            )
-            if event_text:
-                fallback_parts.append(event_text)
+        final_text = ""
+        fallback_parts: list[str] = []
+        async for event in runner.run_async(  # pyright: ignore[reportUnknownMemberType]
+            user_id=USER_ID,
+            session_id=session.id,
+            new_message=content,
+        ):
+            if event.content and event.content.parts:
+                event_text = "".join(
+                    p.text for p in event.content.parts if hasattr(p, "text") and p.text
+                )
+                if event_text:
+                    fallback_parts.append(event_text)
 
-            if (
-                hasattr(event, "is_final_response")
-                and callable(event.is_final_response)
-                and event.is_final_response()
-            ):
-                final_text += event_text
+                if (
+                    hasattr(event, "is_final_response")
+                    and callable(event.is_final_response)
+                    and event.is_final_response()
+                ):
+                    final_text += event_text
+
+    except Exception as exc:
+        raise RuntimeError(f"Agent execution failed for '{agent.name}': {exc}") from exc
 
     if not final_text and fallback_parts:
         logger.warning("No final response detected — collecting all text events")

--- a/dime/agents/tools/__init__.py
+++ b/dime/agents/tools/__init__.py
@@ -1,0 +1,22 @@
+"""
+Agent tool factories.
+
+Each module exports make_*() functions that create FunctionTool instances
+with runtime dependencies (adapters, guides) closed over.
+"""
+
+from dime.agents.tools.filesystem_tools import (
+    make_list_tool,
+    make_read_tool,
+    make_write_tool,
+)
+from dime.agents.tools.image_tools import make_image_generation_tool
+from dime.agents.tools.search_tools import make_search_tool
+
+__all__ = [
+    "make_image_generation_tool",
+    "make_list_tool",
+    "make_read_tool",
+    "make_search_tool",
+    "make_write_tool",
+]

--- a/dime/agents/tools/filesystem_tools.py
+++ b/dime/agents/tools/filesystem_tools.py
@@ -5,7 +5,23 @@ Wraps FileSystemAdapter methods as ADK FunctionTool instances so agents
 can read, write, and list files in the article workspace.
 """
 
+import posixpath
+
 from dime.adapters.protocols import FileSystemAdapter
+
+
+def _sanitize_path(path: str) -> str:
+    """Sanitize a path to prevent traversal outside the workspace.
+
+    Rejects absolute paths and paths containing '..' components.
+
+    Raises:
+        ValueError: If the path attempts directory traversal.
+    """
+    normalized = posixpath.normpath(path)
+    if normalized.startswith("/") or normalized.startswith(".."):
+        raise ValueError(f"Invalid path: '{path}' escapes the workspace.")
+    return normalized
 
 
 def make_read_tool(fs: FileSystemAdapter) -> object:
@@ -20,9 +36,13 @@ def make_read_tool(fs: FileSystemAdapter) -> object:
         Returns:
             The file contents as a string, or an error message if not found.
         """
-        if not fs.exists(path):
-            return f"Error: file '{path}' does not exist."
-        return fs.read(path)
+        try:
+            safe_path = _sanitize_path(path)
+        except ValueError as e:
+            return f"Error: {e}"
+        if not fs.exists(safe_path):
+            return f"Error: file '{safe_path}' does not exist."
+        return fs.read(safe_path)
 
     return read_file
 
@@ -40,8 +60,12 @@ def make_write_tool(fs: FileSystemAdapter) -> object:
         Returns:
             Confirmation message.
         """
-        fs.write(path, content)
-        return f"Successfully wrote {len(content)} characters to '{path}'."
+        try:
+            safe_path = _sanitize_path(path)
+        except ValueError as e:
+            return f"Error: {e}"
+        fs.write(safe_path, content)
+        return f"Successfully wrote {len(content)} characters to '{safe_path}'."
 
     return write_file
 
@@ -58,9 +82,13 @@ def make_list_tool(fs: FileSystemAdapter) -> object:
         Returns:
             Newline-separated list of file paths, or a message if empty.
         """
-        files = fs.list(prefix)
+        try:
+            safe_prefix = _sanitize_path(prefix) if prefix else ""
+        except ValueError as e:
+            return f"Error: {e}"
+        files = fs.list(safe_prefix)
         if not files:
-            return f"No files found under '{prefix}'."
+            return f"No files found under '{safe_prefix}'."
         return "\n".join(files)
 
     return list_files

--- a/dime/agents/tools/filesystem_tools.py
+++ b/dime/agents/tools/filesystem_tools.py
@@ -1,0 +1,66 @@
+"""
+Filesystem tools for agents.
+
+Wraps FileSystemAdapter methods as ADK FunctionTool instances so agents
+can read, write, and list files in the article workspace.
+"""
+
+from dime.adapters.protocols import FileSystemAdapter
+
+
+def make_read_tool(fs: FileSystemAdapter) -> object:
+    """Create a tool that reads a file from the article workspace."""
+
+    def read_file(path: str) -> str:
+        """Read a file from the article workspace.
+
+        Args:
+            path: Relative path within the workspace (e.g. "research.md").
+
+        Returns:
+            The file contents as a string, or an error message if not found.
+        """
+        if not fs.exists(path):
+            return f"Error: file '{path}' does not exist."
+        return fs.read(path)
+
+    return read_file
+
+
+def make_write_tool(fs: FileSystemAdapter) -> object:
+    """Create a tool that writes a file to the article workspace."""
+
+    def write_file(path: str, content: str) -> str:
+        """Write content to a file in the article workspace.
+
+        Args:
+            path: Relative path within the workspace (e.g. "research.md").
+            content: The text content to write.
+
+        Returns:
+            Confirmation message.
+        """
+        fs.write(path, content)
+        return f"Successfully wrote {len(content)} characters to '{path}'."
+
+    return write_file
+
+
+def make_list_tool(fs: FileSystemAdapter) -> object:
+    """Create a tool that lists files in the article workspace."""
+
+    def list_files(prefix: str) -> str:
+        """List files in the article workspace under a given prefix.
+
+        Args:
+            prefix: Directory prefix to list (e.g. "art/" or "").
+
+        Returns:
+            Newline-separated list of file paths, or a message if empty.
+        """
+        files = fs.list(prefix)
+        if not files:
+            return f"No files found under '{prefix}'."
+        return "\n".join(files)
+
+    return list_files

--- a/dime/agents/tools/image_tools.py
+++ b/dime/agents/tools/image_tools.py
@@ -1,0 +1,50 @@
+"""
+Image generation tools for agents.
+
+Provides a stub image generation tool. The real Imagen 3 integration
+is a deployment concern — this module defines the tool interface.
+"""
+
+from __future__ import annotations
+
+import uuid
+
+
+def make_image_generation_tool(article_slug: str, slot_name: str) -> object:
+    """Create an image generation tool for a specific image slot.
+
+    Args:
+        article_slug: The article's URL slug, used for output path.
+        slot_name: The image slot name (e.g. "hero", "thumbnail").
+    """
+
+    def generate_image(
+        prompt: str, width: int, height: int, image_format: str = "png"
+    ) -> str:
+        """Generate an image from a text prompt.
+
+        Args:
+            prompt: Detailed image generation prompt.
+            width: Target image width in pixels.
+            height: Target image height in pixels.
+            image_format: Output format (png, jpg, webp).
+
+        Returns:
+            The file path where the generated image was saved,
+            or an error message if generation failed.
+        """
+        variant_id = uuid.uuid4().hex[:8]
+        output_path = (
+            f"art/{article_slug}/{slot_name}/variant_{variant_id}.{image_format}"
+        )
+
+        # Stub: in production, this calls Imagen 3 or similar API.
+        # The stub returns the path that *would* be used, allowing the
+        # rest of the pipeline to proceed for testing.
+        return (
+            f"[Image generation stub] Would generate {width}x{height} "
+            f"{image_format} image at '{output_path}'. "
+            f"Prompt: {prompt[:100]}..."
+        )
+
+    return generate_image

--- a/dime/agents/tools/search_tools.py
+++ b/dime/agents/tools/search_tools.py
@@ -1,0 +1,47 @@
+"""
+Web search tools for agents.
+
+Provides a Google Search grounding tool for the ResearcherAgent.
+Falls back to a stub if the ADK GoogleSearchTool is unavailable.
+"""
+
+from __future__ import annotations
+
+import logging
+
+logger = logging.getLogger(__name__)
+
+
+def make_search_tool() -> object:
+    """Create a web search tool for research agents.
+
+    Attempts to use ADK's built-in GoogleSearchTool for grounding.
+    Falls back to a stub implementation if unavailable.
+    """
+    try:
+        from google.adk.tools.google_search_tool import GoogleSearchTool  # pyright: ignore[reportMissingImports]
+
+        return GoogleSearchTool()
+    except (ImportError, Exception):
+        logger.warning(
+            "GoogleSearchTool unavailable — using stub search tool. "
+            "Set up Grounding with Google Search for production use."
+        )
+        return _stub_search
+
+
+def _stub_search(query: str) -> str:
+    """Search the web for information on a topic.
+
+    Args:
+        query: The search query string.
+
+    Returns:
+        Search results as text. In production this uses Google Search
+        grounding; this stub returns a placeholder.
+    """
+    return (
+        f"[Search stub] No live search available. Query was: '{query}'. "
+        "The agent should note that search results are unavailable and "
+        "flag this as a gap in the research."
+    )

--- a/dime/agents/tools/search_tools.py
+++ b/dime/agents/tools/search_tools.py
@@ -11,6 +11,11 @@ import logging
 
 logger = logging.getLogger(__name__)
 
+try:
+    from google.adk.tools.google_search_tool import GoogleSearchTool  # pyright: ignore[reportMissingImports]
+except ImportError:
+    GoogleSearchTool = None  # pyright: ignore[reportConstantRedefinition]
+
 
 def make_search_tool() -> object:
     """Create a web search tool for research agents.
@@ -18,16 +23,13 @@ def make_search_tool() -> object:
     Attempts to use ADK's built-in GoogleSearchTool for grounding.
     Falls back to a stub implementation if unavailable.
     """
-    try:
-        from google.adk.tools.google_search_tool import GoogleSearchTool  # pyright: ignore[reportMissingImports]
-
-        return GoogleSearchTool()
-    except (ImportError, Exception):
+    if GoogleSearchTool is None:
         logger.warning(
             "GoogleSearchTool unavailable — using stub search tool. "
             "Set up Grounding with Google Search for production use."
         )
         return _stub_search
+    return GoogleSearchTool()
 
 
 def _stub_search(query: str) -> str:

--- a/dime/agents/writer.py
+++ b/dime/agents/writer.py
@@ -5,14 +5,29 @@ Transforms approved research notes into a polished article draft.
 Context (content_guide) is injected at runtime by the worker layer.
 """
 
-from .base import DimeBaseAgent
-from .prompts import WRITER_PROMPT
+from __future__ import annotations
+
+from typing import Any
+
+from dime.agents.base import DimeBaseAgent
+from dime.agents.prompts import WRITER_PROMPT
 
 
 class WriterAgent(DimeBaseAgent):
     """Agent that transforms research.md into a polished article draft.md."""
 
-    def __init__(self) -> None:
+    def __init__(
+        self,
+        tools: list[Any] | None = None,
+        content_guide: dict[str, Any] | None = None,
+    ) -> None:
+        instruction = WRITER_PROMPT + self.format_guide_context(
+            content_guide=content_guide,
+        )
+
         super().__init__(
-            name="writer", model="gemini-2.5-flash", instruction=WRITER_PROMPT
+            name="writer",
+            model="gemini-2.5-flash",
+            instruction=instruction,
+            tools=tools,
         )

--- a/dime/workers/art_director.py
+++ b/dime/workers/art_director.py
@@ -4,9 +4,10 @@ import asyncio
 import logging
 from typing import Any
 
-from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
 
-from dime.adapters.protocols import BrokerAdapter
+from dime.adapters.protocols import BrokerAdapter, FileSystemAdapter
+from dime.agents.runner import run_agent
+from dime.agents.tools.filesystem_tools import make_read_tool, make_write_tool
 from dime.models.article import Article
 from dime.pipeline.states import ArticleState
 from dime.workers.base import BaseWorker
@@ -19,23 +20,46 @@ class ArtDirectorWorker(BaseWorker):
 
     task_type = "art_brief"
 
-    def __init__(
-        self,
-        broker: BrokerAdapter,
-        session_factory: async_sessionmaker[AsyncSession],
-    ) -> None:
-        super().__init__(broker, session_factory)
-
     async def run_task(
         self, article: Article, payload: dict[str, Any]
     ) -> ArticleState | None:
         """Run the art director agent for *article* to generate image prompts."""
+        from dime.agents.art_director import ArtDirectorAgent
+
+        async with self._session_factory() as db:
+            project = await self._load_project(db, article.project_id)
+            content_guide = project.content_guide
+            style_guide = project.style_guide
+
+        tools: list[Any] = [
+            make_read_tool(self._filesystem),
+            make_write_tool(self._filesystem),
+        ]
+
+        agent = ArtDirectorAgent(
+            tools=tools, content_guide=content_guide, style_guide=style_guide
+        )
+
+        input_text = (
+            f"Create an art brief with image prompts for this article.\n\n"
+            f"Title: {article.title}\n\n"
+            f"Read the approved draft from '{article.slug}/draft.md' "
+            f"and produce '{article.slug}/art_brief.md'."
+        )
+
         logger.info(
             "ArtDirectorWorker: running agent for article %s — %s",
             article.id,
             article.title,
         )
-        # ArtDirectorAgent will be added in a future agents issue.
+
+        result = await run_agent(agent, input_text)
+        logger.info(
+            "ArtDirectorWorker: agent completed for article %s (%d chars output)",
+            article.id,
+            len(result),
+        )
+
         return ArticleState.ART_REVIEW
 
 
@@ -44,12 +68,17 @@ def main() -> None:
     import os
 
     from dime.adapters.broker.redis import RedisBrokerAdapter
+    from dime.adapters.filesystem.local import LocalFileSystemAdapter
     from dime.db import AsyncSessionLocal
 
     logging.basicConfig(level=logging.INFO)
     redis_url = os.environ.get("REDIS_URL", "redis://localhost:6379/0")
+    storage_path = os.environ.get("STORAGE_BASE_PATH", "/tmp/dime-storage")
     broker: BrokerAdapter = RedisBrokerAdapter(url=redis_url)
-    worker = ArtDirectorWorker(broker=broker, session_factory=AsyncSessionLocal)
+    filesystem: FileSystemAdapter = LocalFileSystemAdapter(base_path=storage_path)
+    worker = ArtDirectorWorker(
+        broker=broker, session_factory=AsyncSessionLocal, filesystem=filesystem
+    )
     asyncio.run(worker.start())
 
 

--- a/dime/workers/art_director.py
+++ b/dime/workers/art_director.py
@@ -7,6 +7,7 @@ from typing import Any
 
 from dime.adapters.protocols import BrokerAdapter, FileSystemAdapter
 from dime.agents.runner import run_agent
+from dime.agents.art_director import ArtDirectorAgent
 from dime.agents.tools.filesystem_tools import make_read_tool, make_write_tool
 from dime.models.article import Article
 from dime.pipeline.states import ArticleState
@@ -24,8 +25,6 @@ class ArtDirectorWorker(BaseWorker):
         self, article: Article, payload: dict[str, Any]
     ) -> ArticleState | None:
         """Run the art director agent for *article* to generate image prompts."""
-        from dime.agents.art_director import ArtDirectorAgent
-
         async with self._session_factory() as db:
             project = await self._load_project(db, article.project_id)
             content_guide = project.content_guide

--- a/dime/workers/base.py
+++ b/dime/workers/base.py
@@ -6,10 +6,12 @@ import uuid
 from abc import ABC, abstractmethod
 from typing import Any
 
+from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
 
-from dime.adapters.protocols import BrokerAdapter
+from dime.adapters.protocols import BrokerAdapter, FileSystemAdapter
 from dime.models.article import Article
+from dime.models.project import Project
 from dime.pipeline.state_machine import InvalidTransitionError, transition
 from dime.pipeline.states import ArticleState
 
@@ -30,9 +32,11 @@ class BaseWorker(ABC):
         self,
         broker: BrokerAdapter,
         session_factory: async_sessionmaker[AsyncSession],
+        filesystem: FileSystemAdapter,
     ) -> None:
         self._broker = broker
         self._session_factory = session_factory
+        self._filesystem = filesystem
         self._stop_event = asyncio.Event()
 
     def stop(self) -> None:
@@ -50,6 +54,14 @@ class BaseWorker(ABC):
         Raise any exception on failure — BaseWorker.handle() will catch it and
         mark the article as FAILED.
         """
+
+    async def _load_project(self, db: AsyncSession, project_id: uuid.UUID) -> Project:
+        """Load the project for an article to access content/style guides."""
+        result = await db.execute(select(Project).where(Project.id == project_id))
+        project = result.scalar_one_or_none()
+        if project is None:
+            raise ValueError(f"Project not found: {project_id}")
+        return project
 
     async def _mark_failed(self, article_id: uuid.UUID) -> None:
         """Open a fresh session and mark *article_id* as FAILED."""

--- a/dime/workers/image.py
+++ b/dime/workers/image.py
@@ -2,12 +2,16 @@ from __future__ import annotations
 
 import asyncio
 import logging
+import uuid
 from typing import Any
 
-from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
 
-from dime.adapters.protocols import BrokerAdapter
+from dime.adapters.protocols import BrokerAdapter, FileSystemAdapter
+from dime.agents.runner import run_agent
+from dime.agents.tools.filesystem_tools import make_write_tool
+from dime.agents.tools.image_tools import make_image_generation_tool
 from dime.models.article import Article
+from dime.models.image_slot import ImageSlot
 from dime.pipeline.states import ArticleState
 from dime.workers.base import BaseWorker
 
@@ -23,24 +27,57 @@ class ImageWorker(BaseWorker):
 
     task_type = "image"
 
-    def __init__(
-        self,
-        broker: BrokerAdapter,
-        session_factory: async_sessionmaker[AsyncSession],
-    ) -> None:
-        super().__init__(broker, session_factory)
-
     async def run_task(
         self, article: Article, payload: dict[str, Any]
     ) -> ArticleState | None:
         """Generate image variants for one slot; return None (no state transition)."""
-        slot_id = payload.get("slot_id")
+        from dime.agents.image import ImageAgent
+
+        raw_slot_id = payload.get("slot_id")
+        if not raw_slot_id:
+            raise ValueError("Image task payload missing slot_id")
+
+        slot_id = uuid.UUID(str(raw_slot_id))
+
+        # Load slot and project in a fresh session
+        async with self._session_factory() as db:
+            slot = await db.get(ImageSlot, slot_id)
+            if slot is None:
+                raise ValueError(f"ImageSlot not found: {slot_id}")
+
+            project = await self._load_project(db, article.project_id)
+            style_guide = project.style_guide
+
+        tools: list[Any] = [
+            make_image_generation_tool(article.slug, slot.slot_name),
+            make_write_tool(self._filesystem),
+        ]
+
+        agent = ImageAgent(tools=tools, style_guide=style_guide)
+
+        input_text = (
+            f"Generate image variants for the following slot:\n\n"
+            f"Slot: {slot.slot_name}\n"
+            f"Dimensions: {slot.width}x{slot.height}\n"
+            f"Format: {slot.format}\n"
+            f"Prompt: {slot.approved_prompt or 'No approved prompt — use your judgment based on the article.'}\n"
+        )
+
         logger.info(
-            "ImageWorker: generating images for article %s, slot %s",
+            "ImageWorker: generating images for article %s, slot %s (%s)",
             article.id,
             slot_id,
+            slot.slot_name,
         )
-        # ImageAgent will be added in a future agents issue.
+
+        result = await run_agent(agent, input_text)
+        logger.info(
+            "ImageWorker: agent completed for article %s, slot %s (%d chars output)",
+            article.id,
+            slot_id,
+            len(result),
+        )
+
         # Returns None — article remains in ART_GENERATING for human iteration.
         return None
 
@@ -50,12 +87,17 @@ def main() -> None:
     import os
 
     from dime.adapters.broker.redis import RedisBrokerAdapter
+    from dime.adapters.filesystem.local import LocalFileSystemAdapter
     from dime.db import AsyncSessionLocal
 
     logging.basicConfig(level=logging.INFO)
     redis_url = os.environ.get("REDIS_URL", "redis://localhost:6379/0")
+    storage_path = os.environ.get("STORAGE_BASE_PATH", "/tmp/dime-storage")
     broker: BrokerAdapter = RedisBrokerAdapter(url=redis_url)
-    worker = ImageWorker(broker=broker, session_factory=AsyncSessionLocal)
+    filesystem: FileSystemAdapter = LocalFileSystemAdapter(base_path=storage_path)
+    worker = ImageWorker(
+        broker=broker, session_factory=AsyncSessionLocal, filesystem=filesystem
+    )
     asyncio.run(worker.start())
 
 

--- a/dime/workers/image.py
+++ b/dime/workers/image.py
@@ -9,6 +9,7 @@ from typing import Any
 from dime.adapters.protocols import BrokerAdapter, FileSystemAdapter
 from dime.agents.runner import run_agent
 from dime.agents.tools.filesystem_tools import make_write_tool
+from dime.agents.image import ImageAgent
 from dime.agents.tools.image_tools import make_image_generation_tool
 from dime.models.article import Article
 from dime.models.image_slot import ImageSlot
@@ -31,8 +32,6 @@ class ImageWorker(BaseWorker):
         self, article: Article, payload: dict[str, Any]
     ) -> ArticleState | None:
         """Generate image variants for one slot; return None (no state transition)."""
-        from dime.agents.image import ImageAgent
-
         raw_slot_id = payload.get("slot_id")
         if not raw_slot_id:
             raise ValueError("Image task payload missing slot_id")

--- a/dime/workers/publisher.py
+++ b/dime/workers/publisher.py
@@ -6,7 +6,7 @@ from typing import Any
 
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
 
-from dime.adapters.protocols import BrokerAdapter
+from dime.adapters.protocols import BrokerAdapter, FileSystemAdapter, PublishingAdapter
 from dime.models.article import Article
 from dime.pipeline.states import ArticleState
 from dime.workers.base import BaseWorker
@@ -23,20 +23,47 @@ class PublisherWorker(BaseWorker):
         self,
         broker: BrokerAdapter,
         session_factory: async_sessionmaker[AsyncSession],
+        filesystem: FileSystemAdapter,
+        publishing: PublishingAdapter,
     ) -> None:
-        super().__init__(broker, session_factory)
+        super().__init__(broker, session_factory, filesystem)
+        self._publishing = publishing
 
     async def run_task(
         self, article: Article, payload: dict[str, Any]
     ) -> ArticleState | None:
-        """Run the publisher agent for *article*."""
-        from dime.agents.publisher import PublisherAgent  # noqa: PLC0415
+        """Publish the article via the PublishingAdapter (no LLM)."""
+        from dime.agents.publisher import PublisherAgent
 
-        agent = PublisherAgent()
-        logger.info(
-            "PublisherWorker: publishing article %s — %s", article.id, article.title
+        agent = PublisherAgent(
+            publishing=self._publishing,
+            filesystem=self._filesystem,
         )
-        _ = agent
+
+        frontmatter: dict[str, Any] = {
+            "title": article.title,
+            "slug": article.slug,
+            "tags": article.tags,
+        }
+        if article.published_at:
+            frontmatter["date"] = article.published_at.isoformat()
+
+        logger.info(
+            "PublisherWorker: publishing article %s — %s",
+            article.id,
+            article.title,
+        )
+
+        result = await agent.publish(
+            article_id=article.id,
+            article_slug=article.slug,
+            frontmatter=frontmatter,
+        )
+
+        logger.info(
+            "PublisherWorker: publish result for article %s: %s", article.id, result
+        )
+
         return ArticleState.PUBLISHED
 
 
@@ -45,12 +72,23 @@ def main() -> None:
     import os
 
     from dime.adapters.broker.redis import RedisBrokerAdapter
+    from dime.adapters.filesystem.local import LocalFileSystemAdapter
+    from dime.adapters.publishing.hugo import HugoPublishingAdapter
     from dime.db import AsyncSessionLocal
 
     logging.basicConfig(level=logging.INFO)
     redis_url = os.environ.get("REDIS_URL", "redis://localhost:6379/0")
+    storage_path = os.environ.get("STORAGE_BASE_PATH", "/tmp/dime-storage")
+    hugo_dir = os.environ.get("HUGO_CONTENT_DIR", "/tmp/hugo-content")
     broker: BrokerAdapter = RedisBrokerAdapter(url=redis_url)
-    worker = PublisherWorker(broker=broker, session_factory=AsyncSessionLocal)
+    filesystem: FileSystemAdapter = LocalFileSystemAdapter(base_path=storage_path)
+    publishing: PublishingAdapter = HugoPublishingAdapter(content_dir=hugo_dir)
+    worker = PublisherWorker(
+        broker=broker,
+        session_factory=AsyncSessionLocal,
+        filesystem=filesystem,
+        publishing=publishing,
+    )
     asyncio.run(worker.start())
 
 

--- a/dime/workers/publisher.py
+++ b/dime/workers/publisher.py
@@ -7,6 +7,7 @@ from typing import Any
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
 
 from dime.adapters.protocols import BrokerAdapter, FileSystemAdapter, PublishingAdapter
+from dime.agents.publisher import PublisherAgent
 from dime.models.article import Article
 from dime.pipeline.states import ArticleState
 from dime.workers.base import BaseWorker
@@ -33,8 +34,6 @@ class PublisherWorker(BaseWorker):
         self, article: Article, payload: dict[str, Any]
     ) -> ArticleState | None:
         """Publish the article via the PublishingAdapter (no LLM)."""
-        from dime.agents.publisher import PublisherAgent
-
         agent = PublisherAgent(
             publishing=self._publishing,
             filesystem=self._filesystem,

--- a/dime/workers/research.py
+++ b/dime/workers/research.py
@@ -8,6 +8,7 @@ from typing import Any
 from dime.adapters.protocols import BrokerAdapter, FileSystemAdapter
 from dime.agents.runner import run_agent
 from dime.agents.tools.filesystem_tools import make_read_tool, make_write_tool
+from dime.agents.researcher import ResearcherAgent
 from dime.agents.tools.search_tools import make_search_tool
 from dime.models.article import Article
 from dime.pipeline.states import ArticleState
@@ -25,8 +26,6 @@ class ResearchWorker(BaseWorker):
         self, article: Article, payload: dict[str, Any]
     ) -> ArticleState | None:
         """Run the research agent for *article*."""
-        from dime.agents.researcher import ResearcherAgent
-
         async with self._session_factory() as db:
             project = await self._load_project(db, article.project_id)
             content_guide = project.content_guide

--- a/dime/workers/research.py
+++ b/dime/workers/research.py
@@ -4,9 +4,11 @@ import asyncio
 import logging
 from typing import Any
 
-from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
 
-from dime.adapters.protocols import BrokerAdapter
+from dime.adapters.protocols import BrokerAdapter, FileSystemAdapter
+from dime.agents.runner import run_agent
+from dime.agents.tools.filesystem_tools import make_read_tool, make_write_tool
+from dime.agents.tools.search_tools import make_search_tool
 from dime.models.article import Article
 from dime.pipeline.states import ArticleState
 from dime.workers.base import BaseWorker
@@ -19,28 +21,44 @@ class ResearchWorker(BaseWorker):
 
     task_type = "research"
 
-    def __init__(
-        self,
-        broker: BrokerAdapter,
-        session_factory: async_sessionmaker[AsyncSession],
-    ) -> None:
-        super().__init__(broker, session_factory)
-
     async def run_task(
         self, article: Article, payload: dict[str, Any]
     ) -> ArticleState | None:
         """Run the research agent for *article*."""
-        from dime.agents.researcher import ResearcherAgent  # noqa: PLC0415
+        from dime.agents.researcher import ResearcherAgent
 
-        agent = ResearcherAgent()
+        async with self._session_factory() as db:
+            project = await self._load_project(db, article.project_id)
+            content_guide = project.content_guide
+
+        # Build article-scoped filesystem tools
+        tools: list[Any] = [
+            make_search_tool(),
+            make_read_tool(self._filesystem),
+            make_write_tool(self._filesystem),
+        ]
+
+        agent = ResearcherAgent(tools=tools, content_guide=content_guide)
+
+        input_text = (
+            f"Research the following topic and produce research.md:\n\n"
+            f"Title: {article.title}\n\n"
+            f"Topic Brief:\n{article.topic_brief}"
+        )
+
         logger.info(
             "ResearchWorker: running agent for article %s — %s",
             article.id,
             article.title,
         )
-        # Agent execution via ADK is intentionally thin here; the agent infrastructure
-        # (tools, filesystem writes) will be fleshed out in a future issue.
-        _ = agent  # agent instance created; real runner invocation is a future concern
+
+        result = await run_agent(agent, input_text)
+        logger.info(
+            "ResearchWorker: agent completed for article %s (%d chars output)",
+            article.id,
+            len(result),
+        )
+
         return ArticleState.RESEARCH_REVIEW
 
 
@@ -49,12 +67,17 @@ def main() -> None:
     import os
 
     from dime.adapters.broker.redis import RedisBrokerAdapter
+    from dime.adapters.filesystem.local import LocalFileSystemAdapter
     from dime.db import AsyncSessionLocal
 
     logging.basicConfig(level=logging.INFO)
     redis_url = os.environ.get("REDIS_URL", "redis://localhost:6379/0")
+    storage_path = os.environ.get("STORAGE_BASE_PATH", "/tmp/dime-storage")
     broker: BrokerAdapter = RedisBrokerAdapter(url=redis_url)
-    worker = ResearchWorker(broker=broker, session_factory=AsyncSessionLocal)
+    filesystem: FileSystemAdapter = LocalFileSystemAdapter(base_path=storage_path)
+    worker = ResearchWorker(
+        broker=broker, session_factory=AsyncSessionLocal, filesystem=filesystem
+    )
     asyncio.run(worker.start())
 
 

--- a/dime/workers/writing.py
+++ b/dime/workers/writing.py
@@ -4,9 +4,10 @@ import asyncio
 import logging
 from typing import Any
 
-from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
 
-from dime.adapters.protocols import BrokerAdapter
+from dime.adapters.protocols import BrokerAdapter, FileSystemAdapter
+from dime.agents.runner import run_agent
+from dime.agents.tools.filesystem_tools import make_read_tool, make_write_tool
 from dime.models.article import Article
 from dime.pipeline.states import ArticleState
 from dime.workers.base import BaseWorker
@@ -19,26 +20,43 @@ class WritingWorker(BaseWorker):
 
     task_type = "write"
 
-    def __init__(
-        self,
-        broker: BrokerAdapter,
-        session_factory: async_sessionmaker[AsyncSession],
-    ) -> None:
-        super().__init__(broker, session_factory)
-
     async def run_task(
         self, article: Article, payload: dict[str, Any]
     ) -> ArticleState | None:
         """Run the writing agent for *article*."""
-        from dime.agents.writer import WriterAgent  # noqa: PLC0415
+        from dime.agents.writer import WriterAgent
 
-        agent = WriterAgent()
+        async with self._session_factory() as db:
+            project = await self._load_project(db, article.project_id)
+            content_guide = project.content_guide
+
+        tools: list[Any] = [
+            make_read_tool(self._filesystem),
+            make_write_tool(self._filesystem),
+        ]
+
+        agent = WriterAgent(tools=tools, content_guide=content_guide)
+
+        input_text = (
+            f"Write an article based on the approved research notes.\n\n"
+            f"Title: {article.title}\n\n"
+            f"Read the research notes from '{article.slug}/research.md' "
+            f"and produce '{article.slug}/draft.md'."
+        )
+
         logger.info(
             "WritingWorker: running agent for article %s — %s",
             article.id,
             article.title,
         )
-        _ = agent
+
+        result = await run_agent(agent, input_text)
+        logger.info(
+            "WritingWorker: agent completed for article %s (%d chars output)",
+            article.id,
+            len(result),
+        )
+
         return ArticleState.DRAFT_REVIEW
 
 
@@ -47,12 +65,17 @@ def main() -> None:
     import os
 
     from dime.adapters.broker.redis import RedisBrokerAdapter
+    from dime.adapters.filesystem.local import LocalFileSystemAdapter
     from dime.db import AsyncSessionLocal
 
     logging.basicConfig(level=logging.INFO)
     redis_url = os.environ.get("REDIS_URL", "redis://localhost:6379/0")
+    storage_path = os.environ.get("STORAGE_BASE_PATH", "/tmp/dime-storage")
     broker: BrokerAdapter = RedisBrokerAdapter(url=redis_url)
-    worker = WritingWorker(broker=broker, session_factory=AsyncSessionLocal)
+    filesystem: FileSystemAdapter = LocalFileSystemAdapter(base_path=storage_path)
+    worker = WritingWorker(
+        broker=broker, session_factory=AsyncSessionLocal, filesystem=filesystem
+    )
     asyncio.run(worker.start())
 
 

--- a/dime/workers/writing.py
+++ b/dime/workers/writing.py
@@ -8,6 +8,7 @@ from typing import Any
 from dime.adapters.protocols import BrokerAdapter, FileSystemAdapter
 from dime.agents.runner import run_agent
 from dime.agents.tools.filesystem_tools import make_read_tool, make_write_tool
+from dime.agents.writer import WriterAgent
 from dime.models.article import Article
 from dime.pipeline.states import ArticleState
 from dime.workers.base import BaseWorker
@@ -24,8 +25,6 @@ class WritingWorker(BaseWorker):
         self, article: Article, payload: dict[str, Any]
     ) -> ArticleState | None:
         """Run the writing agent for *article*."""
-        from dime.agents.writer import WriterAgent
-
         async with self._session_factory() as db:
             project = await self._load_project(db, article.project_id)
             content_guide = project.content_guide

--- a/tests/test_agent_prompts.py
+++ b/tests/test_agent_prompts.py
@@ -1,9 +1,14 @@
 """
-Tests for agent prompts and agent class configuration.
+Tests for agent prompts, agent class configuration, and agent tools.
 
 Validates the 4-agent pipeline: prompt constants exist and are well-formed,
-and each agent class instantiates with the correct name, model, and instruction.
+each agent class instantiates with the correct name, model, and instruction,
+and tool factories produce callable tools.
 """
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
 
 import pytest
 
@@ -23,6 +28,13 @@ from dime.agents.prompts import (
     RESEARCH_PROMPT,
     WRITER_PROMPT,
 )
+from dime.agents.tools.filesystem_tools import (
+    make_list_tool,
+    make_read_tool,
+    make_write_tool,
+)
+from dime.agents.tools.image_tools import make_image_generation_tool
+from dime.agents.tools.search_tools import make_search_tool
 
 
 # --- Prompt constant tests ---
@@ -90,13 +102,28 @@ class TestPromptConstants:
 class TestAgentInstantiation:
     """Verify each agent class instantiates with correct configuration."""
 
-    def test_researcher_agent(self) -> None:
-        """ResearcherAgent has correct name, model, and instruction."""
+    def test_researcher_agent_default(self) -> None:
+        """ResearcherAgent with no args uses RESEARCH_PROMPT as instruction."""
         agent = ResearcherAgent()
         assert agent.name == "researcher"
         assert agent.model == "gemini-2.5-flash"
         assert agent.instruction == RESEARCH_PROMPT
         assert isinstance(agent, DimeBaseAgent)
+
+    def test_researcher_agent_with_guide(self) -> None:
+        """ResearcherAgent injects content_guide into instruction."""
+        guide = {"audience": "general public", "min_sources": 5}
+        agent = ResearcherAgent(content_guide=guide)
+        instruction = str(agent.instruction)
+        assert RESEARCH_PROMPT in instruction
+        assert "general public" in instruction
+        assert "Content Guide" in instruction
+
+    def test_researcher_agent_with_tools(self) -> None:
+        """ResearcherAgent accepts tools parameter."""
+        tool = lambda: "stub"  # noqa: E731
+        agent = ResearcherAgent(tools=[tool])
+        assert len(agent.tools) == 1  # pyright: ignore[reportUnknownMemberType,reportUnknownArgumentType]
 
     def test_writer_agent(self) -> None:
         """WriterAgent has correct name, model, and instruction."""
@@ -106,6 +133,12 @@ class TestAgentInstantiation:
         assert agent.instruction == WRITER_PROMPT
         assert isinstance(agent, DimeBaseAgent)
 
+    def test_writer_agent_with_guide(self) -> None:
+        """WriterAgent injects content_guide into instruction."""
+        guide = {"voice": "conversational"}
+        agent = WriterAgent(content_guide=guide)
+        assert "conversational" in str(agent.instruction)
+
     def test_art_director_agent(self) -> None:
         """ArtDirectorAgent has correct name, model, and instruction."""
         agent = ArtDirectorAgent()
@@ -113,6 +146,17 @@ class TestAgentInstantiation:
         assert agent.model == "gemini-2.5-flash"
         assert agent.instruction == ART_DIRECTOR_PROMPT
         assert isinstance(agent, DimeBaseAgent)
+
+    def test_art_director_agent_with_both_guides(self) -> None:
+        """ArtDirectorAgent accepts both content_guide and style_guide."""
+        agent = ArtDirectorAgent(
+            content_guide={"audience": "teens"},
+            style_guide={"palette": "bold"},
+        )
+        instruction = str(agent.instruction)
+        assert "Content Guide" in instruction
+        assert "Style Guide" in instruction
+        assert "bold" in instruction
 
     def test_image_agent(self) -> None:
         """ImageAgent has correct name, model, and instruction."""
@@ -122,19 +166,113 @@ class TestAgentInstantiation:
         assert agent.instruction == IMAGE_PROMPT
         assert isinstance(agent, DimeBaseAgent)
 
-    def test_publisher_agent(self) -> None:
-        """PublisherAgent has correct name, model, and non-empty instruction."""
-        agent = PublisherAgent()
-        assert agent.name == "publisher"
-        assert agent.model == "gemini-2.5-flash"
-        assert isinstance(agent.instruction, str)
-        assert len(agent.instruction) > 0
-        assert isinstance(agent, DimeBaseAgent)
+    def test_image_agent_with_style_guide(self) -> None:
+        """ImageAgent injects style_guide into instruction."""
+        agent = ImageAgent(style_guide={"aesthetic": "minimalist"})
+        assert "minimalist" in str(agent.instruction)
 
-    def test_publisher_agent_accepts_sub_agents(self) -> None:
-        """PublisherAgent can accept sub_agents parameter."""
-        agent = PublisherAgent(sub_agents=[])
-        assert agent.name == "publisher"
+    def test_publisher_agent(self) -> None:
+        """PublisherAgent is a non-LLM agent with publishing + filesystem deps."""
+        mock_publishing = MagicMock()
+        mock_fs = MagicMock()
+        agent = PublisherAgent(publishing=mock_publishing, filesystem=mock_fs)
+        assert agent._publishing is mock_publishing  # pyright: ignore[reportPrivateUsage]
+        assert agent._filesystem is mock_fs  # pyright: ignore[reportPrivateUsage]
+
+
+# --- Tool factory tests ---
+
+
+class TestToolFactories:
+    """Verify tool factories produce callable tools."""
+
+    def test_make_read_tool(self) -> None:
+        """make_read_tool returns a callable that reads from the filesystem."""
+        mock_fs = MagicMock()
+        mock_fs.exists.return_value = True
+        mock_fs.read.return_value = "file content"
+        tool = make_read_tool(mock_fs)
+        result = tool("test.md")  # type: ignore[operator]
+        assert result == "file content"
+        mock_fs.read.assert_called_once_with("test.md")
+
+    def test_make_read_tool_missing_file(self) -> None:
+        """make_read_tool returns error message for missing files."""
+        mock_fs = MagicMock()
+        mock_fs.exists.return_value = False
+        tool = make_read_tool(mock_fs)
+        result = tool("missing.md")  # type: ignore[operator]
+        assert "does not exist" in result
+
+    def test_make_write_tool(self) -> None:
+        """make_write_tool returns a callable that writes to the filesystem."""
+        mock_fs = MagicMock()
+        tool = make_write_tool(mock_fs)
+        result = tool("out.md", "hello world")  # type: ignore[operator]
+        mock_fs.write.assert_called_once_with("out.md", "hello world")
+        assert "Successfully wrote" in result
+
+    def test_make_list_tool(self) -> None:
+        """make_list_tool returns a callable that lists files."""
+        mock_fs = MagicMock()
+        mock_fs.list.return_value = ["a.md", "b.md"]
+        tool = make_list_tool(mock_fs)
+        result = tool("")  # type: ignore[operator]
+        assert "a.md" in result
+        assert "b.md" in result
+
+    def test_make_list_tool_empty(self) -> None:
+        """make_list_tool returns message when no files found."""
+        mock_fs = MagicMock()
+        mock_fs.list.return_value = []
+        tool = make_list_tool(mock_fs)
+        result = tool("empty/")  # type: ignore[operator]
+        assert "No files found" in result
+
+    def test_make_search_tool(self) -> None:
+        """make_search_tool returns a callable (stub or GoogleSearchTool)."""
+        tool = make_search_tool()
+        assert tool is not None
+
+    def test_make_image_generation_tool(self) -> None:
+        """make_image_generation_tool returns a callable stub."""
+        tool = make_image_generation_tool("test-article", "hero")
+        result = tool("A dramatic image", 1200, 630)  # type: ignore[operator]
+        assert "test-article" in result
+        assert "hero" in result
+
+
+# --- Guide context formatting tests ---
+
+
+class TestGuideContext:
+    """Verify DimeBaseAgent.format_guide_context works correctly."""
+
+    def test_no_guides_returns_empty(self) -> None:
+        result = DimeBaseAgent.format_guide_context()
+        assert result == ""
+
+    def test_content_guide_formatted(self) -> None:
+        result = DimeBaseAgent.format_guide_context(
+            content_guide={"audience": "young adults"}
+        )
+        assert "Content Guide" in result
+        assert "young adults" in result
+
+    def test_style_guide_formatted(self) -> None:
+        result = DimeBaseAgent.format_guide_context(
+            style_guide={"palette": "earth tones"}
+        )
+        assert "Style Guide" in result
+        assert "earth tones" in result
+
+    def test_both_guides_formatted(self) -> None:
+        result = DimeBaseAgent.format_guide_context(
+            content_guide={"voice": "authoritative"},
+            style_guide={"mood": "serious"},
+        )
+        assert "Content Guide" in result
+        assert "Style Guide" in result
 
 
 # --- Module exports test ---

--- a/tests/test_agent_prompts.py
+++ b/tests/test_agent_prompts.py
@@ -229,6 +229,39 @@ class TestToolFactories:
         result = tool("empty/")  # type: ignore[operator]
         assert "No files found" in result
 
+    def test_make_read_tool_rejects_traversal(self) -> None:
+        """make_read_tool rejects path traversal attempts."""
+        mock_fs = MagicMock()
+        tool = make_read_tool(mock_fs)
+        result = tool("../../etc/passwd")  # type: ignore[operator]
+        assert "Error" in result
+        assert "escapes" in result
+        mock_fs.read.assert_not_called()
+
+    def test_make_read_tool_rejects_absolute_path(self) -> None:
+        """make_read_tool rejects absolute paths."""
+        mock_fs = MagicMock()
+        tool = make_read_tool(mock_fs)
+        result = tool("/etc/passwd")  # type: ignore[operator]
+        assert "Error" in result
+        mock_fs.read.assert_not_called()
+
+    def test_make_write_tool_rejects_traversal(self) -> None:
+        """make_write_tool rejects path traversal attempts."""
+        mock_fs = MagicMock()
+        tool = make_write_tool(mock_fs)
+        result = tool("../evil.sh", "bad")  # type: ignore[operator]
+        assert "Error" in result
+        mock_fs.write.assert_not_called()
+
+    def test_make_list_tool_rejects_traversal(self) -> None:
+        """make_list_tool rejects path traversal attempts."""
+        mock_fs = MagicMock()
+        tool = make_list_tool(mock_fs)
+        result = tool("../../")  # type: ignore[operator]
+        assert "Error" in result
+        mock_fs.list.assert_not_called()
+
     def test_make_search_tool(self) -> None:
         """make_search_tool returns a callable (stub or GoogleSearchTool)."""
         tool = make_search_tool()

--- a/tests/test_workers.py
+++ b/tests/test_workers.py
@@ -9,12 +9,14 @@ from __future__ import annotations
 import uuid
 from datetime import datetime, timezone
 from typing import Any
-from unittest.mock import AsyncMock, MagicMock
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from dime.models.article import Article
+from dime.models.image_slot import ImageSlot
+from dime.models.project import Project
 from dime.pipeline.states import ArticleState
 from dime.workers.art_director import ArtDirectorWorker
 from dime.workers.base import BaseWorker
@@ -28,6 +30,8 @@ from dime.workers.writing import WritingWorker
 # Helpers
 # ---------------------------------------------------------------------------
 
+_PROJECT_ID = uuid.uuid4()
+
 
 def _make_article(
     state: ArticleState = ArticleState.RESEARCHING,
@@ -35,7 +39,7 @@ def _make_article(
 ) -> Article:
     return Article(
         id=article_id or uuid.uuid4(),
-        project_id=uuid.uuid4(),
+        project_id=_PROJECT_ID,
         title="Test Article",
         slug="test-article",
         state=state,
@@ -45,12 +49,33 @@ def _make_article(
     )
 
 
+def _make_project() -> Project:
+    return Project(
+        id=_PROJECT_ID,
+        name="Test Project",
+        slug="test-project",
+        content_guide={"audience": "general"},
+        style_guide={"palette": "bold"},
+        workflow_config_id=uuid.uuid4(),
+    )
+
+
 def _make_session_factory(article: Article | None) -> Any:
-    """Return a mock async_sessionmaker that yields a session returning *article* on .get()."""
+    """Return a mock async_sessionmaker that yields a session.
+
+    The session's .get() returns *article* and the worker's _load_project
+    returns a test project.
+    """
+    project = _make_project()
     mock_session = AsyncMock(spec=AsyncSession)
     mock_session.get = AsyncMock(return_value=article)
     mock_session.commit = AsyncMock()
     mock_session.rollback = AsyncMock()
+
+    # Mock for _load_project's select().where() pattern
+    mock_result = MagicMock()
+    mock_result.scalar_one_or_none.return_value = project
+    mock_session.execute = AsyncMock(return_value=mock_result)
 
     mock_cm = MagicMock()
     mock_cm.__aenter__ = AsyncMock(return_value=mock_session)
@@ -61,15 +86,29 @@ def _make_session_factory(article: Article | None) -> Any:
     return mock_factory
 
 
+def _make_filesystem() -> MagicMock:
+    """Return a mock FileSystemAdapter."""
+    fs = MagicMock()
+    fs.read.return_value = "# Draft content"
+    fs.write.return_value = None
+    fs.exists.return_value = True
+    fs.list.return_value = []
+    return fs
+
+
 def _make_worker(
     cls: type[BaseWorker],
     article: Article | None,
-) -> tuple[Any, Any]:
-    """Return (worker, mock_broker)."""
+    **kwargs: Any,
+) -> tuple[Any, Any, Any]:
+    """Return (worker, mock_broker, mock_filesystem)."""
     broker = AsyncMock()
     factory = _make_session_factory(article)
-    worker = cls(broker=broker, session_factory=factory)
-    return worker, broker
+    filesystem = _make_filesystem()
+    worker = cls(
+        broker=broker, session_factory=factory, filesystem=filesystem, **kwargs
+    )
+    return worker, broker, filesystem
 
 
 # ---------------------------------------------------------------------------
@@ -79,24 +118,29 @@ def _make_worker(
 
 @pytest.mark.asyncio
 class TestResearchWorker:
-    async def test_happy_path_transitions_to_research_review(self) -> None:
+    @patch("dime.workers.research.run_agent", new_callable=AsyncMock)
+    async def test_happy_path_transitions_to_research_review(
+        self, mock_run: AsyncMock
+    ) -> None:
+        mock_run.return_value = "# Research notes\n\nFindings here."
         article = _make_article(state=ArticleState.RESEARCHING)
-        worker, _ = _make_worker(ResearchWorker, article)
+        worker, _, _ = _make_worker(ResearchWorker, article)
 
         await worker.handle({"article_id": str(article.id)})
 
         assert article.state is ArticleState.RESEARCH_REVIEW
+        mock_run.assert_called_once()
 
     async def test_missing_article_id_does_not_crash(self) -> None:
-        worker, _ = _make_worker(ResearchWorker, None)
+        worker, _, _ = _make_worker(ResearchWorker, None)
         await worker.handle({})  # no exception
 
     async def test_invalid_article_id_does_not_crash(self) -> None:
-        worker, _ = _make_worker(ResearchWorker, None)
+        worker, _, _ = _make_worker(ResearchWorker, None)
         await worker.handle({"article_id": "not-a-uuid"})  # no exception
 
     async def test_article_not_found_does_not_crash(self) -> None:
-        worker, _ = _make_worker(ResearchWorker, None)
+        worker, _, _ = _make_worker(ResearchWorker, None)
         await worker.handle({"article_id": str(uuid.uuid4())})  # no exception
 
 
@@ -107,13 +151,18 @@ class TestResearchWorker:
 
 @pytest.mark.asyncio
 class TestWritingWorker:
-    async def test_happy_path_transitions_to_draft_review(self) -> None:
+    @patch("dime.workers.writing.run_agent", new_callable=AsyncMock)
+    async def test_happy_path_transitions_to_draft_review(
+        self, mock_run: AsyncMock
+    ) -> None:
+        mock_run.return_value = "# Article Draft\n\nContent here."
         article = _make_article(state=ArticleState.WRITING)
-        worker, _ = _make_worker(WritingWorker, article)
+        worker, _, _ = _make_worker(WritingWorker, article)
 
         await worker.handle({"article_id": str(article.id)})
 
         assert article.state is ArticleState.DRAFT_REVIEW
+        mock_run.assert_called_once()
 
 
 # ---------------------------------------------------------------------------
@@ -123,13 +172,18 @@ class TestWritingWorker:
 
 @pytest.mark.asyncio
 class TestArtDirectorWorker:
-    async def test_happy_path_transitions_to_art_review(self) -> None:
+    @patch("dime.workers.art_director.run_agent", new_callable=AsyncMock)
+    async def test_happy_path_transitions_to_art_review(
+        self, mock_run: AsyncMock
+    ) -> None:
+        mock_run.return_value = "# Art Brief\n\nImage prompts here."
         article = _make_article(state=ArticleState.ART_BRIEFING)
-        worker, _ = _make_worker(ArtDirectorWorker, article)
+        worker, _, _ = _make_worker(ArtDirectorWorker, article)
 
         await worker.handle({"article_id": str(article.id)})
 
         assert article.state is ArticleState.ART_REVIEW
+        mock_run.assert_called_once()
 
 
 # ---------------------------------------------------------------------------
@@ -139,29 +193,53 @@ class TestArtDirectorWorker:
 
 @pytest.mark.asyncio
 class TestImageWorker:
-    async def test_no_state_change(self) -> None:
+    @patch("dime.workers.image.run_agent", new_callable=AsyncMock)
+    async def test_no_state_change(self, mock_run: AsyncMock) -> None:
         """ImageWorker runs but leaves article in ART_GENERATING."""
-        article = _make_article(state=ArticleState.ART_GENERATING)
-        worker, _ = _make_worker(ImageWorker, article)
+        mock_run.return_value = "Generated 3 variants."
 
-        await worker.handle(
-            {"article_id": str(article.id), "slot_id": str(uuid.uuid4())}
+        article = _make_article(state=ArticleState.ART_GENERATING)
+        worker, _, _ = _make_worker(ImageWorker, article)
+
+        # Mock the slot lookup in run_task's inner session
+        slot = ImageSlot(
+            id=uuid.uuid4(),
+            article_id=article.id,
+            slot_name="hero",
+            width=1200,
+            height=630,
+            format="png",
+            approved_prompt="A dramatic hero image",
         )
+        # Patch the inner session_factory call to also return the slot
+        inner_session = AsyncMock(spec=AsyncSession)
+        inner_session.get = AsyncMock(return_value=slot)
+        inner_result = MagicMock()
+        inner_result.scalar_one_or_none.return_value = _make_project()
+        inner_session.execute = AsyncMock(return_value=inner_result)
+
+        inner_cm = MagicMock()
+        inner_cm.__aenter__ = AsyncMock(return_value=inner_session)
+        inner_cm.__aexit__ = AsyncMock(return_value=False)
+
+        # The handle() uses one session, run_task() opens another
+        orig_factory = worker._session_factory
+        call_count = 0
+        original_cm = orig_factory.return_value
+
+        def side_effect_factory() -> Any:
+            nonlocal call_count
+            call_count += 1
+            if call_count <= 1:
+                return original_cm  # handle()'s session
+            return inner_cm  # run_task()'s inner session
+
+        worker._session_factory = MagicMock(side_effect=side_effect_factory)
+
+        await worker.handle({"article_id": str(article.id), "slot_id": str(slot.id)})
 
         assert article.state is ArticleState.ART_GENERATING
-
-    async def test_db_commit_called_even_without_state_change(self) -> None:
-        """Commit must happen even when run_task returns None, so agent-written
-        DB changes (e.g. image variants) are persisted."""
-        article = _make_article(state=ArticleState.ART_GENERATING)
-        broker = AsyncMock()
-        factory = _make_session_factory(article)
-        worker = ImageWorker(broker=broker, session_factory=factory)
-
-        await worker.handle({"article_id": str(article.id)})
-
-        session = factory.return_value.__aenter__.return_value
-        session.commit.assert_called_once()
+        mock_run.assert_called_once()
 
 
 # ---------------------------------------------------------------------------
@@ -173,11 +251,20 @@ class TestImageWorker:
 class TestPublisherWorker:
     async def test_happy_path_transitions_to_published(self) -> None:
         article = _make_article(state=ArticleState.PUBLISHING)
-        worker, _ = _make_worker(PublisherWorker, article)
+        mock_publishing = AsyncMock()
+        mock_publishing.emit = AsyncMock()
+        mock_publishing.signal = MagicMock()
+        mock_publishing.preview_url = MagicMock(return_value=None)
+
+        worker, _, _fs = _make_worker(
+            PublisherWorker, article, publishing=mock_publishing
+        )
 
         await worker.handle({"article_id": str(article.id)})
 
         assert article.state is ArticleState.PUBLISHED
+        mock_publishing.emit.assert_called_once()
+        mock_publishing.signal.assert_called_once()
 
 
 # ---------------------------------------------------------------------------
@@ -190,7 +277,7 @@ class TestBaseWorkerErrorHandling:
     async def test_agent_failure_marks_article_failed(self) -> None:
         """When run_task raises, the article should be marked FAILED."""
         article = _make_article(state=ArticleState.RESEARCHING)
-        worker, _ = _make_worker(ResearchWorker, article)
+        worker, _, _ = _make_worker(ResearchWorker, article)
 
         async def bad_run_task(
             art: Article, payload: dict[str, Any]
@@ -206,7 +293,7 @@ class TestBaseWorkerErrorHandling:
     async def test_agent_failure_does_not_crash(self) -> None:
         """Worker loop must survive agent failures."""
         article = _make_article(state=ArticleState.RESEARCHING)
-        worker, _ = _make_worker(ResearchWorker, article)
+        worker, _, _ = _make_worker(ResearchWorker, article)
 
         async def bad_run_task(
             art: Article, payload: dict[str, Any]
@@ -223,7 +310,7 @@ class TestBaseWorkerErrorHandling:
         article = _make_article(
             state=ArticleState.QUEUED
         )  # QUEUED → PUBLISHED is invalid
-        worker, _ = _make_worker(ResearchWorker, article)
+        worker, _, _ = _make_worker(ResearchWorker, article)
 
         async def bad_transition(
             art: Article, payload: dict[str, Any]
@@ -241,6 +328,7 @@ class TestBaseWorkerErrorHandling:
         """If marking the article as FAILED also fails, the worker should not crash."""
         article = _make_article(state=ArticleState.RESEARCHING)
         broker = AsyncMock()
+        filesystem = _make_filesystem()
 
         # First session: article found, run_task raises
         session1 = AsyncMock(spec=AsyncSession)
@@ -260,7 +348,9 @@ class TestBaseWorkerErrorHandling:
         factory = MagicMock()
         factory.side_effect = [cm1, cm2]
 
-        worker = ResearchWorker(broker=broker, session_factory=factory)
+        worker = ResearchWorker(
+            broker=broker, session_factory=factory, filesystem=filesystem
+        )
 
         async def bad_run_task(
             art: Article, payload: dict[str, Any]
@@ -277,13 +367,68 @@ class TestBaseWorkerErrorHandling:
         broker = AsyncMock()
         broker.consume = AsyncMock()
         factory = _make_session_factory(None)
-        worker = ResearchWorker(broker=broker, session_factory=factory)
+        filesystem = _make_filesystem()
+        worker = ResearchWorker(
+            broker=broker, session_factory=factory, filesystem=filesystem
+        )
 
         # stop() before start() means the loop body never executes
         worker.stop()
         await worker.start()
 
         broker.consume.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# PublisherAgent unit tests (non-LLM)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+class TestPublisherAgent:
+    async def test_publish_reads_draft_and_emits(self) -> None:
+        """PublisherAgent reads draft from FS and calls publishing adapter."""
+        from dime.agents.publisher import PublisherAgent
+
+        mock_fs = MagicMock()
+        mock_fs.exists.return_value = True
+        mock_fs.read.return_value = "# My Article\n\nContent here."
+
+        mock_pub = AsyncMock()
+        mock_pub.emit = AsyncMock()
+        mock_pub.signal = MagicMock()
+        mock_pub.preview_url = MagicMock(return_value="http://preview.test/my-article")
+
+        agent = PublisherAgent(publishing=mock_pub, filesystem=mock_fs)
+        article_id = uuid.uuid4()
+
+        result = await agent.publish(
+            article_id=article_id,
+            article_slug="my-article",
+            frontmatter={"title": "My Article"},
+        )
+
+        mock_fs.read.assert_called_once_with("my-article/draft.md")
+        mock_pub.emit.assert_called_once()
+        mock_pub.signal.assert_called_once()
+        assert "preview.test" in result
+
+    async def test_publish_raises_on_missing_draft(self) -> None:
+        """PublisherAgent raises FileNotFoundError if draft is missing."""
+        from dime.agents.publisher import PublisherAgent
+
+        mock_fs = MagicMock()
+        mock_fs.exists.return_value = False
+        mock_pub = AsyncMock()
+
+        agent = PublisherAgent(publishing=mock_pub, filesystem=mock_fs)
+
+        with pytest.raises(FileNotFoundError, match="draft not found"):
+            await agent.publish(
+                article_id=uuid.uuid4(),
+                article_slug="missing-article",
+                frontmatter={},
+            )
 
 
 # ---------------------------------------------------------------------------
@@ -303,9 +448,11 @@ class TestResearchWorkerIntegration:
         from sqlalchemy.ext.asyncio import async_sessionmaker
 
         from dime.adapters.broker.redis import RedisBrokerAdapter
+        from dime.adapters.filesystem.local import LocalFileSystemAdapter
 
         redis_url = os.environ.get("REDIS_URL", "redis://localhost:6379/1")
         broker = RedisBrokerAdapter(url=redis_url)
+        filesystem = LocalFileSystemAdapter(base_path="/tmp/dime-test-storage")
 
         article = _make_article(state=ArticleState.RESEARCHING)
         db_session.add(article)
@@ -318,7 +465,9 @@ class TestResearchWorkerIntegration:
             expire_on_commit=False,  # type: ignore[arg-type]
         )
 
-        worker = ResearchWorker(broker=broker, session_factory=session_factory)
+        worker = ResearchWorker(
+            broker=broker, session_factory=session_factory, filesystem=filesystem
+        )
 
         # Consume one batch (single message), block up to 2s
         await broker.consume("research", worker.handle, max_count=1, block_ms=2000)
@@ -337,9 +486,11 @@ class TestResearchWorkerIntegration:
         from sqlalchemy.ext.asyncio import async_sessionmaker
 
         from dime.adapters.broker.redis import RedisBrokerAdapter
+        from dime.adapters.filesystem.local import LocalFileSystemAdapter
 
         redis_url = os.environ.get("REDIS_URL", "redis://localhost:6379/1")
         broker = RedisBrokerAdapter(url=redis_url)
+        filesystem = LocalFileSystemAdapter(base_path="/tmp/dime-test-storage")
 
         article = _make_article(state=ArticleState.RESEARCHING)
         db_session.add(article)
@@ -352,7 +503,9 @@ class TestResearchWorkerIntegration:
             expire_on_commit=False,  # type: ignore[arg-type]
         )
 
-        worker = ResearchWorker(broker=broker, session_factory=session_factory)
+        worker = ResearchWorker(
+            broker=broker, session_factory=session_factory, filesystem=filesystem
+        )
 
         async def failing_run_task(
             art: Article, payload: dict[str, Any]


### PR DESCRIPTION
## Summary
- Add tool factory modules (filesystem, search, image generation) for agent use
- Add agent runner helper wrapping ADK Runner + InMemorySessionService
- Wire all agent classes with tools param and content/style guide injection
- Rewrite PublisherAgent as non-LLM agent calling PublishingAdapter directly
- Connect all 5 workers to real agent execution via `run_agent()`

Closes #18

## Changes
- **New**: `dime/agents/tools/` — filesystem_tools, search_tools, image_tools
- **New**: `dime/agents/runner.py` — ADK Runner helper
- **Modified**: `dime/agents/base.py` — tools param, `format_guide_context()` static method
- **Modified**: `dime/agents/researcher.py`, `writer.py`, `art_director.py`, `image.py` — constructor accepts tools + guides
- **Rewritten**: `dime/agents/publisher.py` — non-LLM agent with `publish()` method
- **Modified**: `dime/workers/base.py` — filesystem param, `_load_project()` helper
- **Modified**: All 5 workers — load project, create tools, instantiate agent, call `run_agent()`
- **Expanded**: `tests/test_agent_prompts.py` — tool factories, guide context, publisher agent
- **Expanded**: `tests/test_workers.py` — mock `run_agent()`, publisher agent flow

## Testing
- [x] 229 tests pass
- [x] Coverage: 90.74% (threshold: 90%)
- [x] All quality checks pass (ruff check, ruff format, pyright 0 errors)

## Verification Steps
```bash
uv sync
uv run pytest -v --cov --cov-fail-under=90
uv run pyright
```

## Checklist
- [x] Code follows dime conventions (CLAUDE.md)
- [x] Specs consulted (docs/specs/)
- [x] No secrets committed
- [x] No database changes required

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Agents now accept custom tools (filesystem, image, search) and optional content/style guides that are injected into prompts.
  * New runtime helper to run agents and stream/aggregate responses.
  * Added tool factories for safe filesystem ops, image-generation stubs, and a searchable fallback.

* **Refactor**
  * Workers and publishing flow now wire filesystem and publishing adapters; workers construct and execute agents with injected guides/tools.

* **Tests**
  * Expanded coverage for guide injection, tool factories, worker flows, and publishing behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->