### PR TITLE
Add AstroAdapter publishing adapter (Issue #19)

### DIFF
--- a/dime/adapters/factory.py
+++ b/dime/adapters/factory.py
@@ -11,7 +11,7 @@ from dime.adapters.protocols import (
     NotificationAdapter,
     PublishingAdapter,
 )
-from dime.adapters.publishing.hugo import HugoPublishingAdapter
+from dime.adapters.publishing.astro import AstroAdapter
 from dime.config.settings import DimeSettings
 
 
@@ -33,8 +33,12 @@ def build_adapters(settings: DimeSettings) -> AdapterSet:
     filesystem: FileSystemAdapter = LocalFileSystemAdapter(
         base_path=settings.STORAGE_BASE_PATH
     )
-    publishing: PublishingAdapter = HugoPublishingAdapter(
-        content_dir=settings.HUGO_CONTENT_DIR
+    publishing: PublishingAdapter = AstroAdapter(
+        art_dir=settings.ASTRO_ART_DIR,
+        acts_of_defiance_public_dir=settings.ASTRO_PUBLIC_DIR,
+        signal_file_path=settings.ASTRO_SIGNAL_FILE,
+        content_base=settings.ASTRO_CONTENT_BASE,
+        preview_host=settings.ASTRO_PREVIEW_HOST,
     )
     notification: NotificationAdapter = WebSocketNotificationAdapter()
     return AdapterSet(

--- a/dime/adapters/publishing/__init__.py
+++ b/dime/adapters/publishing/__init__.py
@@ -1,3 +1,4 @@
+from dime.adapters.publishing.astro import AstroAdapter
 from dime.adapters.publishing.hugo import HugoPublishingAdapter
 
-__all__ = ["HugoPublishingAdapter"]
+__all__ = ["AstroAdapter", "HugoPublishingAdapter"]

--- a/dime/adapters/publishing/astro.py
+++ b/dime/adapters/publishing/astro.py
@@ -1,0 +1,97 @@
+"""
+Astro publishing adapter.
+
+Implements PublishingAdapter for the acts-of-defiance Astro site.
+Copies images from the local art/ directory into the Astro public/images/
+directory and writes a signal file to trigger an Astro build.
+
+Markdown is NOT copied — Astro reads directly from compendium/ at build
+time (DECISION-012). Images come from the local art/ filesystem (DECISION-013).
+"""
+
+from __future__ import annotations
+
+import logging
+import shutil
+import uuid
+from pathlib import Path
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+
+class AstroAdapter:
+    """PublishingAdapter for the acts-of-defiance Astro site.
+
+    Copies article images from art/{slug}/ into the Astro public images
+    directory and touches a signal file to trigger a site rebuild.
+    """
+
+    def __init__(
+        self,
+        art_dir: str,
+        acts_of_defiance_public_dir: str,
+        signal_file_path: str,
+        content_base: str = "",
+        preview_host: str = "",
+    ) -> None:
+        self._art_dir = Path(art_dir)
+        self._public_dir = Path(acts_of_defiance_public_dir)
+        self._signal_file = Path(signal_file_path)
+        self._content_base = content_base
+        self._preview_host = preview_host
+
+    async def emit(
+        self,
+        article_id: uuid.UUID,
+        content: str,
+        frontmatter: dict[str, Any],
+    ) -> None:
+        """Copy article images into the Astro public directory.
+
+        Markdown is not touched — Astro reads compendium/ directly at build
+        time. Only images referenced in frontmatter['images'] are copied.
+
+        Args:
+            article_id: Article UUID (unused — slug comes from frontmatter).
+            content: Article markdown body (unused — already in compendium/).
+            frontmatter: Article frontmatter dict; must include 'slug' and
+                optionally 'images' with filenames sourced from art/.
+        """
+        slug: str = frontmatter.get("slug", str(article_id))
+        images: dict[str, Any] = frontmatter.get("images", {})
+
+        if not images:
+            logger.info("AstroAdapter.emit: no images in frontmatter for %s", slug)
+            return
+
+        dest_dir = self._public_dir / slug
+        dest_dir.mkdir(parents=True, exist_ok=True)
+
+        for slot_name, filename in images.items():
+            if not filename:
+                continue
+            src = self._art_dir / slug / filename
+            if not src.exists():
+                logger.warning(
+                    "AstroAdapter.emit: image not found — %s (slot: %s, article: %s)",
+                    src,
+                    slot_name,
+                    slug,
+                )
+                continue
+            dest = dest_dir / filename
+            shutil.copy2(src, dest)
+            logger.info("AstroAdapter.emit: copied %s → %s", src, dest)
+
+    def signal(self) -> None:
+        """Touch the signal file to trigger an Astro build."""
+        self._signal_file.parent.mkdir(parents=True, exist_ok=True)
+        self._signal_file.touch()
+        logger.info("AstroAdapter.signal: touched %s", self._signal_file)
+
+    def preview_url(self) -> str | None:
+        """Return the local Astro dev server URL, or None if not configured."""
+        if not self._preview_host:
+            return None
+        return f"http://{self._preview_host}"

--- a/dime/config/settings.py
+++ b/dime/config/settings.py
@@ -133,6 +133,13 @@ class DimeSettings(BaseSettings):
     # ==========================================================================
     HUGO_CONTENT_DIR: str = "./hugo-content"
 
+    # Astro adapter settings
+    ASTRO_ART_DIR: str = "./art"
+    ASTRO_PUBLIC_DIR: str = "./acts-of-defiance/public/images/articles"
+    ASTRO_SIGNAL_FILE: str = "./acts-of-defiance/.rebuild-signal"
+    ASTRO_CONTENT_BASE: str = "./compendium"
+    ASTRO_PREVIEW_HOST: str = ""
+
     def __init__(self, **kwargs: Any) -> None:
         """Initialize settings with environment validation."""
         super().__init__(**kwargs)  # pyright: ignore[reportUnknownArgumentType]

--- a/tests/test_adapters.py
+++ b/tests/test_adapters.py
@@ -32,6 +32,7 @@ from dime.adapters.protocols import (
     NotificationAdapter,
     PublishingAdapter,
 )
+from dime.adapters.publishing.astro import AstroAdapter
 from dime.adapters.publishing.hugo import HugoPublishingAdapter
 from dime.config.settings import reload_settings
 
@@ -341,11 +342,11 @@ class TestAdapterFactory:
             result = build_adapters(settings)
         assert isinstance(result.filesystem, LocalFileSystemAdapter)
 
-    def test_build_adapters_publishing_is_hugo(self, test_env: Any) -> None:
+    def test_build_adapters_publishing_is_astro(self, test_env: Any) -> None:
         settings = reload_settings()
         with patch("redis.asyncio.from_url"):
             result = build_adapters(settings)
-        assert isinstance(result.publishing, HugoPublishingAdapter)
+        assert isinstance(result.publishing, AstroAdapter)
 
     def test_build_adapters_notification_is_websocket(self, test_env: Any) -> None:
         settings = reload_settings()

--- a/tests/test_astro_adapter.py
+++ b/tests/test_astro_adapter.py
@@ -1,0 +1,234 @@
+"""Tests for AstroAdapter."""
+
+from __future__ import annotations
+
+import uuid
+from pathlib import Path
+
+import pytest
+
+from dime.adapters.protocols import PublishingAdapter
+from dime.adapters.publishing.astro import AstroAdapter
+
+
+def _make_adapter(
+    tmp_path: Path,
+    preview_host: str = "",
+) -> tuple[AstroAdapter, Path, Path, Path]:
+    """Return (adapter, art_dir, public_dir, signal_file)."""
+    art_dir = tmp_path / "art"
+    art_dir.mkdir()
+    public_dir = tmp_path / "public" / "images" / "articles"
+    public_dir.mkdir(parents=True)
+    signal_file = tmp_path / ".rebuild-signal"
+
+    adapter = AstroAdapter(
+        art_dir=str(art_dir),
+        acts_of_defiance_public_dir=str(public_dir),
+        signal_file_path=str(signal_file),
+        content_base=str(tmp_path / "compendium"),
+        preview_host=preview_host,
+    )
+    return adapter, art_dir, public_dir, signal_file
+
+
+# ---------------------------------------------------------------------------
+# Protocol compliance
+# ---------------------------------------------------------------------------
+
+
+class TestProtocolCompliance:
+    def test_astro_is_publishing_adapter(self, tmp_path: Path) -> None:
+        adapter, *_ = _make_adapter(tmp_path)
+        assert isinstance(adapter, PublishingAdapter)
+
+
+# ---------------------------------------------------------------------------
+# emit()
+# ---------------------------------------------------------------------------
+
+
+class TestEmit:
+    @pytest.mark.asyncio
+    async def test_emit_copies_hero_image(self, tmp_path: Path) -> None:
+        adapter, art_dir, public_dir, _ = _make_adapter(tmp_path)
+
+        slug = "frantz-fanon"
+        (art_dir / slug).mkdir()
+        src_img = art_dir / slug / "hero.jpg"
+        src_img.write_bytes(b"fake-image-data")
+
+        await adapter.emit(
+            article_id=uuid.uuid4(),
+            content="# Frantz Fanon",
+            frontmatter={"slug": slug, "images": {"hero": "hero.jpg"}},
+        )
+
+        dest = public_dir / slug / "hero.jpg"
+        assert dest.exists()
+        assert dest.read_bytes() == b"fake-image-data"
+
+    @pytest.mark.asyncio
+    async def test_emit_creates_dest_dir(self, tmp_path: Path) -> None:
+        adapter, art_dir, public_dir, _ = _make_adapter(tmp_path)
+
+        slug = "new-article"
+        (art_dir / slug).mkdir()
+        (art_dir / slug / "hero.png").write_bytes(b"img")
+
+        await adapter.emit(
+            article_id=uuid.uuid4(),
+            content="",
+            frontmatter={"slug": slug, "images": {"hero": "hero.png"}},
+        )
+
+        assert (public_dir / slug).is_dir()
+        assert (public_dir / slug / "hero.png").exists()
+
+    @pytest.mark.asyncio
+    async def test_emit_is_idempotent(self, tmp_path: Path) -> None:
+        adapter, art_dir, public_dir, _ = _make_adapter(tmp_path)
+
+        slug = "idempotent-article"
+        (art_dir / slug).mkdir()
+        src = art_dir / slug / "hero.jpg"
+        src.write_bytes(b"version-1")
+
+        article_id = uuid.uuid4()
+        fm = {"slug": slug, "images": {"hero": "hero.jpg"}}
+
+        await adapter.emit(article_id=article_id, content="", frontmatter=fm)
+        # Overwrite source with different content
+        src.write_bytes(b"version-2")
+        await adapter.emit(article_id=article_id, content="", frontmatter=fm)
+
+        dest = public_dir / slug / "hero.jpg"
+        assert dest.exists()
+        assert dest.read_bytes() == b"version-2"
+
+    @pytest.mark.asyncio
+    async def test_emit_no_images_is_safe(self, tmp_path: Path) -> None:
+        adapter, *_ = _make_adapter(tmp_path)
+        # Should not raise even with empty images dict
+        await adapter.emit(
+            article_id=uuid.uuid4(),
+            content="",
+            frontmatter={"slug": "no-images"},
+        )
+
+    @pytest.mark.asyncio
+    async def test_emit_missing_image_logs_warning_does_not_raise(
+        self, tmp_path: Path
+    ) -> None:
+        adapter, art_dir, public_dir, _ = _make_adapter(tmp_path)
+        slug = "missing-img"
+        (art_dir / slug).mkdir()
+        # Do NOT create the source image
+
+        await adapter.emit(
+            article_id=uuid.uuid4(),
+            content="",
+            frontmatter={"slug": slug, "images": {"hero": "nonexistent.jpg"}},
+        )
+
+        assert not (public_dir / slug / "nonexistent.jpg").exists()
+
+    @pytest.mark.asyncio
+    async def test_emit_uses_article_id_as_slug_fallback(self, tmp_path: Path) -> None:
+        adapter, art_dir, public_dir, _ = _make_adapter(tmp_path)
+        article_id = uuid.uuid4()
+        slug_fallback = str(article_id)
+        (art_dir / slug_fallback).mkdir()
+        (art_dir / slug_fallback / "hero.jpg").write_bytes(b"data")
+
+        await adapter.emit(
+            article_id=article_id,
+            content="",
+            frontmatter={"images": {"hero": "hero.jpg"}},  # no slug key
+        )
+
+        assert (public_dir / slug_fallback / "hero.jpg").exists()
+
+    @pytest.mark.asyncio
+    async def test_emit_copies_multiple_images(self, tmp_path: Path) -> None:
+        adapter, art_dir, public_dir, _ = _make_adapter(tmp_path)
+        slug = "multi-img"
+        (art_dir / slug).mkdir()
+        (art_dir / slug / "hero.jpg").write_bytes(b"hero")
+        (art_dir / slug / "thumb.png").write_bytes(b"thumb")
+
+        await adapter.emit(
+            article_id=uuid.uuid4(),
+            content="",
+            frontmatter={
+                "slug": slug,
+                "images": {"hero": "hero.jpg", "thumb": "thumb.png"},
+            },
+        )
+
+        assert (public_dir / slug / "hero.jpg").exists()
+        assert (public_dir / slug / "thumb.png").exists()
+
+    @pytest.mark.asyncio
+    async def test_emit_skips_empty_image_filename(self, tmp_path: Path) -> None:
+        adapter, art_dir, public_dir, _ = _make_adapter(tmp_path)
+        slug = "empty-filename"
+        (art_dir / slug).mkdir()
+
+        await adapter.emit(
+            article_id=uuid.uuid4(),
+            content="",
+            frontmatter={"slug": slug, "images": {"hero": ""}},
+        )
+
+        # No files should be created for empty filename
+        assert (
+            not list((public_dir / slug).glob("*"))
+            if (public_dir / slug).exists()
+            else True
+        )
+
+
+# ---------------------------------------------------------------------------
+# signal()
+# ---------------------------------------------------------------------------
+
+
+class TestSignal:
+    def test_signal_creates_file(self, tmp_path: Path) -> None:
+        adapter, _, _, signal_file = _make_adapter(tmp_path)
+        assert not signal_file.exists()
+        adapter.signal()
+        assert signal_file.exists()
+
+    def test_signal_is_idempotent(self, tmp_path: Path) -> None:
+        adapter, _, _, signal_file = _make_adapter(tmp_path)
+        adapter.signal()
+        adapter.signal()
+        assert signal_file.exists()
+
+    def test_signal_creates_parent_dirs(self, tmp_path: Path) -> None:
+        signal_file = tmp_path / "deep" / "nested" / ".signal"
+        adapter = AstroAdapter(
+            art_dir=str(tmp_path),
+            acts_of_defiance_public_dir=str(tmp_path),
+            signal_file_path=str(signal_file),
+        )
+        adapter.signal()
+        assert signal_file.exists()
+
+
+# ---------------------------------------------------------------------------
+# preview_url()
+# ---------------------------------------------------------------------------
+
+
+class TestPreviewUrl:
+    def test_preview_url_with_host(self, tmp_path: Path) -> None:
+        adapter, *_ = _make_adapter(tmp_path, preview_host="localhost:4321")
+        url = adapter.preview_url()
+        assert url == "http://localhost:4321"
+
+    def test_preview_url_none_when_no_host(self, tmp_path: Path) -> None:
+        adapter, *_ = _make_adapter(tmp_path, preview_host="")
+        assert adapter.preview_url() is None


### PR DESCRIPTION
## Summary
- Implement `AstroAdapter` — the concrete `PublishingAdapter` for the acts-of-defiance Astro site
- Images are copied from `art/{slug}/` into `acts-of-defiance/public/images/articles/{slug}/`
- Markdown is **not** copied — Astro reads `compendium/` directly at build time (DECISION-012)
- Signal file is written after emit to trigger Astro build (DECISION-013)

Closes #19

## Changes
- **New**: `dime/adapters/publishing/astro.py` — `AstroAdapter` implementation
- **Modified**: `dime/adapters/publishing/__init__.py` — exports `AstroAdapter`
- **Modified**: `dime/adapters/factory.py` — factory now builds `AstroAdapter`
- **Modified**: `dime/config/settings.py` — added 5 Astro settings (`ASTRO_ART_DIR`, `ASTRO_PUBLIC_DIR`, `ASTRO_SIGNAL_FILE`, `ASTRO_CONTENT_BASE`, `ASTRO_PREVIEW_HOST`)
- **New**: `tests/test_astro_adapter.py` — 14 tests, 100% coverage of adapter
- **Modified**: `tests/test_adapters.py` — updated factory test from Hugo to Astro

## Design Decisions Applied
- **DECISION-012**: No markdown copy — adapter only moves images
- **DECISION-013**: Images sourced from local `art/`, not GCS
- `slug` derived from `frontmatter['slug']`, falls back to `str(article_id)`
- Missing images log a warning and skip gracefully (don't crash the publish flow)
- `shutil.copy2` ensures idempotent overwrites

## Testing
- [x] 14 new tests in `tests/test_astro_adapter.py`
- [x] 247 total tests pass
- [x] Coverage: 91.13% (threshold: 90%)
- [x] All quality checks pass (ruff, pyright 0 errors)

## Verification Steps
```bash
uv sync
uv run pytest tests/test_astro_adapter.py -v
uv run pytest --cov --cov-fail-under=90
```

## Checklist
- [x] Satisfies `PublishingAdapter` protocol (pyright validates)
- [x] Idempotent — second emit() overwrites safely
- [x] Signal file written after successful emit
- [x] No secrets committed
- [x] No database changes required

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Publishing system now supports Astro adapter with automatic image file handling and build-trigger signaling capabilities.
  * Added configurable preview URL for article previews.

* **Configuration**
  * New settings for Astro paths: art directory, public output directory, signal file path, content base, and preview host.

* **Tests**
  * Comprehensive test coverage for new publishing adapter including image copying, build signaling, and preview URL functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->